### PR TITLE
 Add a --keep-v option to not drop `v` at the beginning of version numbers

### DIFF
--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -6,14 +6,15 @@
 
 open Bos_setup
 
-let bistro () =
+let bistro () keep_v =
   begin
     let verb = Cmd.(v "--verbosity" % Logs.(level_to_string (level ()))) in
+    let args = if keep_v then Cmd.(verb % "--keep-v") else verb in
     let dune_release = Cmd.(v "dune-release") in
-    OS.Cmd.run Cmd.(dune_release % "distrib" %% verb)
-    >>= fun () -> OS.Cmd.run Cmd.(dune_release % "publish" %% verb)
-    >>= fun () -> OS.Cmd.run Cmd.(dune_release % "opam" %% verb % "pkg")
-    >>= fun () -> OS.Cmd.run Cmd.(dune_release % "opam" %% verb % "submit")
+    OS.Cmd.run Cmd.(dune_release % "distrib" %% args)
+    >>= fun () -> OS.Cmd.run Cmd.(dune_release % "publish" %% args)
+    >>= fun () -> OS.Cmd.run Cmd.(dune_release % "opam" %% args % "pkg")
+    >>= fun () -> OS.Cmd.run Cmd.(dune_release % "opam" %% args % "submit")
     >>= fun () -> Ok 0
   end
   |> Cli.handle_error
@@ -37,7 +38,7 @@ dune-release opam submit   # Submit it to OCaml's opam repository";
     `P "See dune-release(7) for more information."; ]
 
 let cmd =
-  Term.(pure bistro $ Cli.setup),
+  Term.(pure bistro $ Cli.setup $ Cli.keep_v),
   Term.info "bistro" ~doc ~sdocs ~exits ~man ~man_xrefs
 
 (*---------------------------------------------------------------------------

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -41,6 +41,10 @@ let dist_version =
   let docv = "VERSION" in
   Arg.(value & opt (some string) None & info ["dist-version"] ~doc ~docv)
 
+let keep_v =
+  let doc = "Do not drop the initial 'v' in the version string." in
+  Arg.(value & flag & info ["keep-v"] ~doc)
+
 let dist_file =
   let doc = "The package distribution archive. If absent the file
              $(i,BUILD_DIR)/$(i,NAME)-$(i,VERSION).tbz (see options

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -23,6 +23,10 @@ val dist_name : string option Term.t
 val dist_version : string option Term.t
 (** A [--dist-version] option to define the package version. *)
 
+val keep_v: bool Term.t
+(** A [--keep-v] option to not drop the 'v' at the beginning of
+   version strings. *)
+
 val dist_file : Fpath.t option Term.t
 (** A [--dist-file] option to define the distribution archive file. *)
 

--- a/bin/distrib.ml
+++ b/bin/distrib.ml
@@ -62,11 +62,11 @@ let log_wrote_archive ar =
   Logs.app (fun m -> m "Wrote archive %a" Text.Pp.path ar); Ok ()
 
 let distrib
-    () opam build_dir name version keep_dir skip_lint skip_build
+    () opam keep_v build_dir name version keep_dir skip_lint skip_build
     skip_tests
   =
   begin
-    let pkg = Pkg.v ?name ?version ?build_dir ?opam () in
+    let pkg = Pkg.v ?name ~drop_v:(not keep_v) ?version ?build_dir ?opam () in
     Pkg.distrib_archive pkg ~keep_dir
     >>= fun ar -> log_wrote_archive ar
     >>= fun () -> check_archive pkg ar ~skip_lint ~skip_build ~skip_tests
@@ -156,7 +156,7 @@ let man =
          across platforms."); ]
 
 let cmd =
-  Term.(pure distrib $ Cli.setup $ Cli.dist_opam $
+  Term.(pure distrib $ Cli.setup $ Cli.dist_opam $ Cli.keep_v $
         Cli.build_dir $ Cli.dist_name $ Cli.dist_version $ keep_build_dir $
         skip_lint $ skip_build $ skip_tests),
   Term.info "distrib" ~doc ~sdocs ~exits ~envs ~man ~man_xrefs

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -72,13 +72,13 @@ let field pkg field = match field with
 
 (* Command *)
 
-let opam () build_dir
+let opam () build_dir keep_v
     dist_name dist_version dist_opam dist_uri dist_file
     pkg_opam_dir pkg_name pkg_version pkg_opam pkg_descr
     readme change_log publish_msg action field_name
   =
   let p =
-    Pkg.v
+    Pkg.v ~drop_v:(not keep_v)
       ?build_dir ?name:pkg_name ?version:pkg_version ?opam:pkg_opam
       ?opam_descr:pkg_descr ?readme ?change_log ?publish_msg ()
   in
@@ -86,7 +86,7 @@ let opam () build_dir
   | `Descr -> descr p
   | `Pkg ->
       let dist_p =
-        Pkg.v
+        Pkg.v ~drop_v:(not keep_v)
           ?build_dir ?name:dist_name ?version:dist_version ?opam:dist_opam
           ?distrib_uri:dist_uri ?distrib_file:dist_file ?readme ?change_log
           ?publish_msg ()
@@ -187,7 +187,7 @@ let man =
 
 let cmd =
   let info = Term.info "opam" ~doc ~sdocs ~envs ~man ~man_xrefs in
-  let t = Term.(pure opam $ Cli.setup $ Cli.build_dir $
+  let t = Term.(pure opam $ Cli.setup $ Cli.build_dir $ Cli.keep_v $
                 Cli.dist_name $ Cli.dist_version $ Cli.dist_opam $
                 Cli.dist_uri $ Cli.dist_file $
                 pkg_opam_dir $ Cli.pkg_name $ pkg_version $ pkg_opam $

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -31,7 +31,7 @@ let publish_distrib pkg =
   >>= fun archive -> Github.publish_distrib pkg ~msg ~archive
 
 let publish ()
-    build_dir name version opam change_log distrib_uri
+    build_dir keep_v name version opam change_log distrib_uri
     distrib_file publish_msg publish_artefacts
   =
   begin
@@ -39,7 +39,7 @@ let publish ()
     | [] -> None
     | v -> Some v
     in
-    let pkg = Pkg.v ?name ?version ?build_dir ?opam
+    let pkg = Pkg.v ?name ?version ?build_dir ?opam ~drop_v:(not keep_v)
         ?change_log ?distrib_uri ?distrib_file ?publish_msg
         ?publish_artefacts ()
     in
@@ -96,7 +96,7 @@ let man =
         "Publishes the documentation of a distribution archive on the WWW."); ]
 
 let cmd =
-  Term.(pure publish $ Cli.setup $ Cli.build_dir $
+  Term.(pure publish $ Cli.setup $ Cli.build_dir $ Cli.keep_v $
         Cli.dist_name $ Cli.dist_version $ Cli.dist_opam $
         Cli.change_log $ Cli.dist_uri $ Cli.dist_file $
         Cli.publish_msg $ artefacts),

--- a/bin/status.ml
+++ b/bin/status.ml
@@ -25,10 +25,10 @@ let pp_status ppf (dirty, version, changes) = match changes with
       pp_since version pp_dirty dirty (Fmt.list pp_commit) changes
 
 let parse_version v =
-  let version =
+  let prefix, version =
     if String.is_prefix ~affix:"v" v
-    then String.with_index_range ~first:1 v
-    else v
+    then Some "v", String.with_index_range ~first:1 v
+    else None, v
   in
   try match String.cut ~sep:"." version with
   | None -> None
@@ -37,14 +37,14 @@ let parse_version v =
       match String.cut ~sep:"." rest with
       | None ->
           begin match String.cut ~sep:"+" rest with
-          | None -> Some (maj, int_of_string rest, 0, None)
-          | Some (min, i) ->  Some (maj, int_of_string min, 0, Some i)
+          | None -> Some (prefix, maj, int_of_string rest, 0, None)
+          | Some (min, i) ->  Some (prefix, maj, int_of_string min, 0, Some i)
           end
       | Some (min, rest) ->
           let min = int_of_string min in
           begin match String.cut ~sep:"+" rest with
-          | None -> Some (maj, min, int_of_string rest, None)
-          | Some (p, i) -> Some (maj, min, int_of_string p, Some i)
+          | None -> Some (prefix, maj, min, int_of_string rest, None)
+          | Some (p, i) -> Some (prefix, maj, min, int_of_string p, Some i)
           end
   with
   | Failure _ -> None

--- a/lib/archive.ml
+++ b/lib/archive.ml
@@ -128,11 +128,11 @@ let tar dir ~exclude_paths ~root ~mtime =
 
 (* Bzip2 compression and unarchiving *)
 
-let bzip2_cmd = OS.Env.(value "TOPKG_BZIP2" cmd ~absent:(Cmd.v "bzip2"))
+let bzip2_cmd = OS.Env.(value "DUNE_RELEASE_BZIP2" cmd ~absent:(Cmd.v "bzip2"))
 let ensure_bzip2 () = OS.Cmd.must_exist bzip2_cmd >>| fun _ -> ()
 let bzip2 s ~dst = OS.Cmd.(in_string s |> run_io bzip2_cmd |> to_file dst)
 
-let tar_cmd = OS.Env.(value "TOPKG_TAR" cmd ~absent:(Cmd.v "tar"))
+let tar_cmd = OS.Env.(value "DUNE_RELEASE_TAR" cmd ~absent:(Cmd.v "tar"))
 let ensure_tar () = OS.Cmd.must_exist tar_cmd >>| fun _ -> ()
 let untbz ?(clean = false) ar =
   let clean_dir dir = OS.Dir.exists dir >>= function

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -16,6 +16,7 @@ type t
 val v :
   ?name:string ->
   ?version:string ->
+  ?drop_v:bool ->
   ?build_dir:Fpath.t ->
   ?opam:Fpath.t ->
   ?opam_descr:Fpath.t ->

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -30,11 +30,11 @@ let dirtify id = id ^ "-dirty"
 type t = kind * Cmd.t * Fpath.t
 
 let git =
-  let git = Cmd.v (OS.Env.opt_var "TOPKG_GIT" ~absent:"git") in
+  let git = Cmd.v (OS.Env.opt_var "DUNE_RELEASE_GIT" ~absent:"git") in
   lazy (OS.Cmd.exists git >>= fun exists -> Ok (exists, git))
 
 let hg =
-  let hg = Cmd.v (OS.Env.opt_var "TOPKG_HG" ~absent:"hg") in
+  let hg = Cmd.v (OS.Env.opt_var "DUNE_RELEASE_HG" ~absent:"hg") in
   lazy (OS.Cmd.exists hg >>= fun exists -> Ok (exists, hg))
 
 let vcs_cmd kind cmd dir = match kind with


### PR DESCRIPTION
/cc @diml 

I've done a minimal amount of testing with sexplib0 with `dune-release distrib --keep-v` and `dune-release opam --keep-v` and that seems to work fine.