### PR TITLE
Add a --dry-run option to all commands

### DIFF
--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -6,10 +6,11 @@
 
 open Bos_setup
 
-let bistro () keep_v =
+let bistro () dry_run keep_v =
   begin
-    let verb = Cmd.(v "--verbosity" % Logs.(level_to_string (level ()))) in
-    let args = if keep_v then Cmd.(verb % "--keep-v") else verb in
+    let args = Cmd.(v "--verbosity" % Logs.(level_to_string (level ()))) in
+    let args = if keep_v then Cmd.(args % "--keep-v") else args in
+    let args = if dry_run then Cmd.(args % "--dry-run") else args in
     let dune_release = Cmd.(v "dune-release") in
     OS.Cmd.run Cmd.(dune_release % "distrib" %% args)
     >>= fun () -> OS.Cmd.run Cmd.(dune_release % "publish" %% args)
@@ -38,7 +39,7 @@ dune-release opam submit   # Submit it to OCaml's opam repository";
     `P "See dune-release(7) for more information."; ]
 
 let cmd =
-  Term.(pure bistro $ Cli.setup $ Cli.keep_v),
+  Term.(pure bistro $ Cli.setup $ Cli.dry_run $ Cli.keep_v),
   Term.info "bistro" ~doc ~sdocs ~exits ~man ~man_xrefs
 
 (*---------------------------------------------------------------------------

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -97,6 +97,12 @@ let publish_msg =
   let docv = "MSG" in
   Arg.(value & opt (some string) None & info ["m"; "message"] ~doc ~docv)
 
+let dry_run =
+  let doc =
+    "Don't actually perform any action, just show what would be done."
+  in
+  Arg.(value & flag & info ["dry-run"] ~doc)
+
 (* Terms *)
 
 let setup style_renderer log_level cwd =

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -51,6 +51,9 @@ val build_dir : Fpath.t option Term.t
 val publish_msg : string option Term.t
 (** A [--msg] option to define a publication message. *)
 
+val dry_run: bool Term.t
+(** A [--dry-run] option to do not perform any action. *)
+
 (** {1 Terms} *)
 
 val setup : unit Term.t

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -7,11 +7,11 @@
 open Bos_setup
 open Dune_release
 
-let lint () name lints =
+let lint () dry_run name lints =
   begin
     let pkg = Pkg.v ?name () in
     OS.Dir.current ()
-    >>= fun dir -> Pkg.lint pkg ~dir lints
+    >>= fun dir -> Pkg.lint ~dry_run ~dir pkg lints
   end
   |> Cli.handle_error
 
@@ -45,7 +45,7 @@ let man =
         dune-release-distrib(1) for more details." ]
 
 let cmd =
-  Term.(pure lint $ Cli.setup $ Cli.pkg_name $ lints),
+  Term.(pure lint $ Cli.setup $ Cli.dry_run $ Cli.pkg_name $ lints),
   Term.info "lint" ~doc ~sdocs ~exits ~man ~man_xrefs
 
 

--- a/lib/archive.ml
+++ b/lib/archive.ml
@@ -130,13 +130,15 @@ let tar dir ~exclude_paths ~root ~mtime =
 
 let bzip2_cmd = OS.Env.(value "DUNE_RELEASE_BZIP2" cmd ~absent:(Cmd.v "bzip2"))
 let ensure_bzip2 () = OS.Cmd.must_exist bzip2_cmd >>| fun _ -> ()
-let bzip2 s ~dst = OS.Cmd.(in_string s |> run_io bzip2_cmd |> to_file dst)
+
+let bzip2 ~dry_run ~dst s =
+  Sos.run_io ~dry_run ~default:() bzip2_cmd (OS.Cmd.in_string s) (OS.Cmd.to_file dst)
 
 let tar_cmd = OS.Env.(value "DUNE_RELEASE_TAR" cmd ~absent:(Cmd.v "tar"))
 let ensure_tar () = OS.Cmd.must_exist tar_cmd >>| fun _ -> ()
-let untbz ?(clean = false) ar =
+let untbz ~dry_run ?(clean = false) ar =
   let clean_dir dir = OS.Dir.exists dir >>= function
-    | true when clean -> OS.Dir.delete ~recurse:true dir
+    | true when clean -> Sos.delete_dir ~dry_run dir
     | _ -> Ok ()
   in
   let archive_dir, ar = Fpath.split_base ar in
@@ -144,10 +146,10 @@ let untbz ?(clean = false) ar =
     let dir = Fpath.rem_ext ar in
     OS.Cmd.must_exist tar_cmd
     >>= fun _  -> clean_dir dir
-    >>= fun () -> OS.Cmd.run Cmd.(tar_cmd % "-xjf" % p ar)
+    >>= fun () -> Sos.run ~dry_run Cmd.(tar_cmd % "-xjf" % p ar)
     >>= fun () -> Ok Fpath.(archive_dir // dir)
   in
-  R.join @@ OS.Dir.with_current archive_dir unarchive ar
+  R.join @@ Sos.with_dir ~dry_run archive_dir unarchive ar
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/archive.mli
+++ b/lib/archive.mli
@@ -30,13 +30,13 @@ val tar :
 val ensure_bzip2 : unit -> (unit, R.msg) result
 (** [ensure_bzip2 ()] makes sure the [bzip2] utility is available. *)
 
-val bzip2 : string -> dst:Fpath.t -> (unit, R.msg) result
-(** [bzip2 s dst] compresses [s] to [dst] using bzip2. *)
+val bzip2 : dry_run:bool -> dst:Fpath.t -> string -> (unit, R.msg) result
+(** [bzip2 dst s] compresses [s] to [dst] using bzip2. *)
 
 val ensure_tar : unit -> (unit, R.msg) result
 (** [ensure_tar ()] makes sure the [tar] utility is available. *)
 
-val untbz : ?clean:bool -> Fpath.t -> (Fpath.t, R.msg) result
+val untbz : dry_run:bool -> ?clean:bool -> Fpath.t -> (Fpath.t, R.msg) result
 (** [untbz ~clean ar] untars the tar bzip2 archive [ar] in the same
     directory as [ar] and returns a base directory for [ar]. If [clean]
     is [true] (defaults to [false]) first delete the base directory if

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -11,14 +11,15 @@ open Bos_setup
 (** {1 Publish} *)
 
 val publish_distrib :
-  Pkg.t -> msg:string -> archive:Fpath.t ->
-  (unit, R.msg) Result.result
+  dry_run: bool -> msg:string -> archive:Fpath.t ->
+  Pkg.t -> (unit, R.msg) Result.result
 
 val publish_doc :
-  Pkg.t -> msg:string -> docdir:Fpath.t ->
-  (unit, R.msg) Result.result
+  dry_run: bool -> msg:string -> docdir:Fpath.t ->
+  Pkg.t -> (unit, R.msg) Result.result
 
 val publish_in_git_branch :
+  dry_run: bool ->
   remote:string -> branch:string ->
   name:string -> version:string -> docdir:Fpath.t ->
   dir:Fpath.t -> (unit, R.msg) result

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -19,8 +19,9 @@ val ensure_publish : unit -> (unit, R.msg) result
 (** [ensure_publish ()] makes sure [opam-publish] is in the executable
     search PATH. *)
 
-val submit : ?msg:string -> pkg_dir:Fpath.t -> (unit, R.msg) result
-(** [submit ~pkg_dir] submits the package [pkg_dir] with [opam-publish]
+val submit : dry_run:bool -> ?msg:string -> pkg_dir:Fpath.t ->
+  unit -> (unit, R.msg) result
+(** [submit ~pkg_dir ()] submits the package [pkg_dir] with [opam-publish]
     and submission message [msg] (if any) to the OCaml opam repository. *)
 
 (** {1:pkgs Packages} *)
@@ -91,7 +92,8 @@ module Url : sig
   (** [v ~uri ~checksum] is an URL file for URI [uri] with
       checksum [checksum]. *)
 
-  val with_distrib_file : uri:string -> Fpath.t -> (string, R.msg) result
+  val with_distrib_file :
+    dry_run:bool -> uri:string -> Fpath.t -> (string, R.msg) result
   (** [with_distrib_file ~uri f] is an URL file for URI [uri] with
       the checksum of file [f]. *)
 end

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -71,7 +71,7 @@ val distrib_uri : ?raw:bool -> t -> (string, R.msg) result
     defaults to [false], [p]'s raw URI distribution pattern is
     returned. *)
 
-val distrib_file : t -> (Fpath.t, R.msg) result
+val distrib_file : dry_run:bool -> t -> (Fpath.t, R.msg) result
 (** [distrib_file p] is [p]'s distribution archive. *)
 
 val publish_msg : t -> (string, R.msg) result
@@ -79,7 +79,7 @@ val publish_msg : t -> (string, R.msg) result
 
 (** {1 Distribution} *)
 
-val distrib_archive : t -> keep_dir:bool -> (Fpath.t, R.msg) result
+val distrib_archive : dry_run:bool -> t -> keep_dir:bool -> (Fpath.t, R.msg) result
 (** [distrib_archive p ~keep_dir] creates a distribution archive for
     [p] and returns its path. If [keep_dir] is [true] the repository
     checkout used to create the distribution archive is kept in the
@@ -102,20 +102,23 @@ val distrib_owner_and_repo : t -> (string * string, R.msg) result
 (** {1 Test} *)
 
 val test :
-  t -> dir:Fpath.t -> args:Cmd.t ->
-  out:(OS.Cmd.run_out -> ('a, R.msg) result) -> ('a, R.msg) result
+  dry_run:bool -> dir:Fpath.t -> args:Cmd.t ->
+  out:(OS.Cmd.run_out -> ('a, R.msg) result) ->
+  t -> ('a, R.msg) result
 
 (** {1 Build} *)
 
 val build :
-  t -> dir:Fpath.t -> args:Cmd.t ->
-  out:(OS.Cmd.run_out -> ('a, R.msg) result) -> ('a, R.msg) result
+  dry_run:bool -> dir:Fpath.t -> args:Cmd.t ->
+  out:(OS.Cmd.run_out -> ('a, R.msg) result) ->
+  t -> ('a, R.msg) result
 
 (** {1 Clean} *)
 
 val clean :
-  t -> dir:Fpath.t -> args:Cmd.t ->
-  out:(OS.Cmd.run_out -> ('a, R.msg) result) -> ('a, R.msg) result
+  dry_run:bool -> dir:Fpath.t -> args:Cmd.t ->
+  out:(OS.Cmd.run_out -> ('a, R.msg) result) ->
+  t -> ('a, R.msg) result
 
 (** {1 Lint} *)
 
@@ -125,7 +128,7 @@ type lint = [ `Std_files |`Opam ]
 val lint_all : lint list
 (** [lint_all] is a list with all lint values. *)
 
-val lint : t -> dir:Fpath.t -> lint list -> (int, R.msg) result
+val lint : dry_run:bool -> dir:Fpath.t -> t -> lint list -> (int, R.msg) result
 (** [distrib ~ignore_pkg p ~dir lints] performs the lints mentioned in
     [lints] in a directory [dir] on the package [p].  If [ignore_pkg]
     is [true] [p]'s definitions are ignored. *)

--- a/lib/sos.ml
+++ b/lib/sos.ml
@@ -1,0 +1,114 @@
+(*
+ * Copyright (c) 2018 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Bos_setup
+
+type error = Rresult.R.msg
+
+let root = match OS.Dir.current () with
+| Error (`Msg e) -> Fmt.failwith "invalid root: %s" e
+| Ok d -> d
+
+let current_dir () =
+  match OS.Dir.current () with
+  | Error (`Msg e) -> Fmt.failwith "invalid current directory: %s" e
+  | Ok dir         ->
+      if Fpath.equal dir root then None else
+      match Fpath.relativize ~root dir with
+      | None   -> assert false
+      | Some d ->
+          assert (List.hd (Fpath.segs d) = "_build");
+          Some d
+
+let show ?(color=`Yellow) fmt =
+  Fmt.kstrf (fun s ->
+      let pp_cwd ppf () = match current_dir () with
+      | None   -> ()
+      | Some d -> Fmt.pf ppf "[%a] " Fmt.(styled `Underline Fpath.pp) d
+      in
+      Logs.app (fun m ->m "%a %a%s" Fmt.(styled color string) "=>" pp_cwd () s);
+      Ok ()
+    ) fmt
+
+let run ~dry_run v =
+  if not dry_run then OS.Cmd.run v
+  else show "exec:@[@ %a@]" Cmd.pp v
+
+let run_out ~dry_run ?err v =
+  if not dry_run then OS.Cmd.run_out v
+  else
+  let _ = show "exec:@[@ %a@]" Cmd.pp v in
+  OS.Cmd.run_out ?err Cmd.(v "true")
+
+let run_io ~dry_run ~default v i f =
+  if not dry_run then OS.Cmd.run_io v i |> f
+  else
+  let _ = show "exec:@[@ %a@]" Cmd.pp v in
+  Ok default
+
+let delete_dir ~dry_run dir =
+  if not dry_run then OS.Dir.delete ~recurse:true dir
+  else (
+    let dir' = match current_dir () with
+    | None   -> dir
+    | Some d -> Fpath.(d // dir)
+    in
+    let _ = show ~color:`Green "rmdir %a" Fpath.pp dir' in
+    OS.Dir.delete ~recurse:true dir
+  )
+
+let delete_path ~dry_run p =
+  if not dry_run then OS.Path.delete ~recurse:true p
+  else (
+    let p' = match current_dir () with
+    | None   -> p
+    | Some d -> Fpath.(d // p)
+    in
+    let _ = show ~color:`Green "rm %a" Fpath.pp p' in
+    OS.Path.delete ~recurse:true p
+  )
+
+let write_file ~dry_run p v =
+  if not dry_run then OS.File.write p v
+  else show "write %a" Fpath.pp p
+
+let read_file ~dry_run p =
+  if not dry_run then OS.File.read p
+  else
+  let _ = show "read %a" Fpath.pp p in
+  Ok ""
+
+let file_exists ~dry_run p =
+  if not dry_run then OS.File.exists p
+  else
+  let _ = show "exists %a" Fpath.pp p in
+  Ok true
+
+let with_dir ~dry_run dir f x =
+  if not dry_run then OS.Dir.with_current dir f x
+  else match OS.Dir.exists dir with
+  | Ok true ->
+      let _ = show ~color:`Green "chdir %a" Fpath.pp dir in
+      OS.Dir.with_current dir f x
+  | _ ->
+      let _ = show "chdir %a" Fpath.pp dir in
+      Ok (f x)
+
+let file_must_exist ~dry_run f =
+  if not dry_run then OS.File.must_exist f
+  else
+  let _ = show "must exists %a" Fpath.pp f in
+  Ok f

--- a/lib/sos.mli
+++ b/lib/sos.mli
@@ -1,0 +1,42 @@
+(*
+ * Copyright (c) 2018 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Safe OS operations.
+
+    All the commands in that module can have side-effects. They also
+    all take a [--dry-run] paramater which cause the side-effect to be
+    discarded and to display a message instead.
+*)
+
+type error = Rresult.R.msg
+
+val run: dry_run:bool -> Bos.Cmd.t -> (unit, error) result
+
+val run_io: dry_run:bool ->
+  default:'a -> Bos.Cmd.t -> Bos.OS.Cmd.run_in ->
+  (Bos.OS.Cmd.run_out -> ('a, 'b) result) -> ('a, 'b) result
+
+val run_out:
+  dry_run:bool -> ?err:Bos.OS.Cmd.run_err -> Bos.Cmd.t -> Bos.OS.Cmd.run_out
+
+val delete_dir: dry_run:bool -> Fpath.t -> (unit, error) result
+val delete_path: dry_run:bool -> Fpath.t -> (unit, error) result
+val read_file: dry_run:bool -> Fpath.t -> (string, error) result
+val write_file: dry_run:bool -> Fpath.t -> string -> (unit, error) result
+val with_dir: dry_run:bool -> Fpath.t -> ('a -> 'b) -> 'a -> ('b,  error) result
+
+val file_exists: dry_run:bool -> Fpath.t -> (bool, error) result
+val file_must_exist: dry_run:bool -> Fpath.t -> (Fpath.t, error) result

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -98,19 +98,21 @@ val tracked_files : ?tree_ish:string -> t -> (Fpath.t list, R.msg) result
 
 (** {1:ops Repository operations} *)
 
-val clone : t -> dir:Fpath.t -> (unit, R.msg) result
-(** [clone r ~dir] clones [r] in directory [dir]. *)
+val clone : dry_run:bool -> dir:Fpath.t -> t -> (unit, R.msg) result
+(** [clone ~dir r] clones [r] in directory [dir]. *)
 
-val checkout : ?branch:string -> t -> commit_ish:commit_ish -> (unit, R.msg) result
+val checkout : dry_run:bool ->
+  ?branch:string -> t -> commit_ish:commit_ish -> (unit, R.msg) result
 (** [checkout r ~branch commit_ish] checks out [commit_ish]. Checks
     out in a new branch [branch] if provided. *)
 
-val commit_files : ?msg:string -> t -> Fpath.t list -> (unit, R.msg) result
+val commit_files : dry_run:bool ->
+  ?msg:string -> t -> Fpath.t list -> (unit, R.msg) result
 (** [commit_files r ~msg files] commits the file [files] with message
     [msg] (if unspecified the VCS should prompt). *)
 
 val tag :
-  ?force:bool -> ?sign:bool -> ?msg:string -> ?commit_ish:string -> t ->
+  dry_run:bool -> ?force:bool -> ?sign:bool -> ?msg:string -> ?commit_ish:string -> t ->
   string -> (unit, R.msg) result
 (** [tag r ~force ~sign ~msg ~commit_ish t] tags [commit_ish] with [t]
     and message [msg] (if unspecified the VCS should prompt).  if
@@ -118,7 +120,7 @@ val tag :
     only).  If [force] is [true] (default to [false]) doesn't fail if
     the tag already exists. *)
 
-val delete_tag : t -> string -> (unit, R.msg) result
+val delete_tag : dry_run:bool -> t -> string -> (unit, R.msg) result
 (** [delete_tag r t] deletes tag [t] in repo [r]. *)
 
 (*---------------------------------------------------------------------------


### PR DESCRIPTION
This allow to see what the tool will do before doing it.

Related to #17 (/cc @Drup)

It pretty useful to debug too, as it allows to play with the tools without being afraid of pushing/deleting the wrong stuff.