### PR TITLE
publish: do not force push all the tags to a random repo

### DIFF
--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -7,10 +7,6 @@
 open Bos_setup
 open Dune_release
 
-let extract_version change_log =
-  Text.change_log_file_last_entry change_log
-  >>= fun (version, _) -> Ok version
-
 let vcs_tag tag ~dry_run ~commit_ish ~force ~sign ~delete ~msg =
   let msg = match msg with None -> strf "Distribution %s" tag | Some m -> m in
   Vcs.get ()
@@ -25,7 +21,7 @@ let tag () dry_run name change_log tag commit_ish force sign delete msg =
     let pkg = Pkg.v ~dry_run ?change_log ?name () in
     let tag = match tag with
     | Some t -> Ok t
-    | None -> Pkg.change_log pkg >>= fun cl -> extract_version cl
+    | None   -> Pkg.tag pkg
     in
     tag
     >>= fun tag -> vcs_tag tag ~dry_run ~commit_ish ~force ~sign ~delete ~msg

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -121,8 +121,12 @@ let drop_initial_v version = match String.head version with
 
 let dev_repo p =
   opam_field_hd p "dev-repo" >>= function
-  | Some r -> Ok (Some (chop_git_prefix r))
   | None   -> Ok None
+  | Some r ->
+      let uri = chop_git_prefix r in
+      match String.cut ~sep:"https://github.com/" uri with
+      | Some ("", path) -> Ok (Some ("git@github.com:" ^ path))
+      | _ -> Ok (Some uri)
 
 let distrib_uri ?(raw = false) p =
   let subst_uri p uri =

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -119,6 +119,11 @@ let drop_initial_v version = match String.head version with
 | Some ('v' | 'V') -> String.with_index_range ~first:1 version
 | None | Some _ -> version
 
+let dev_repo p =
+  opam_field_hd p "dev-repo" >>= function
+  | Some r -> Ok (Some (chop_git_prefix r))
+  | None   -> Ok None
+
 let distrib_uri ?(raw = false) p =
   let subst_uri p uri =
     uri
@@ -483,6 +488,14 @@ let lint ~dry_run ~dir p todo =
                      (Fmt.styled_unit `Red "failure") () n); 1
   in
   Sos.with_dir ~dry_run dir lint p
+
+(* tags *)
+
+let extract_version change_log =
+  Text.change_log_file_last_entry change_log
+  >>= fun (version, _) -> Ok version
+
+let tag pkg = change_log pkg >>= fun cl -> extract_version cl
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -132,6 +132,13 @@ val lint : dry_run:bool -> dir:Fpath.t -> t -> lint list -> (int, R.msg) result
     [lints] in a directory [dir] on the package [p].  If [ignore_pkg]
     is [true] [p]'s definitions are ignored. *)
 
+(** {1 Tag} *)
+
+val tag: t -> (string, Sos.error) result
+
+(** {1 Dev repo} *)
+
+val dev_repo: t -> (string option, Sos.error) result
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -135,6 +135,14 @@ let git_tags r =
   run_git ~dry_run:false r Cmd.(v "tag" % "--list")
     ~default:D.list OS.Cmd.out_lines
 
+let git_tag_exists ~dry_run r tag =
+  match
+    run_git ~dry_run r Cmd.(v "rev-parse" % "--verify" % tag)
+      ~default:D.unit OS.Cmd.out_null
+  with
+  | Ok () -> true
+  | _     -> false
+
 let git_changes ~after ~until r =
   let range =
     if after = "" then until else
@@ -385,6 +393,10 @@ let describe ?(dirty = true) ?(commit_ish = "HEAD") = function
 let tags = function
 | (`Git, _, _ as r) -> git_tags r
 | (`Hg, _, _ as r) -> hg_tags r
+
+let tag_exists ~dry_run r tag = match r with
+| (`Git, _, _ as r) -> git_tag_exists r ~dry_run tag
+| (`Hg, _, _) -> failwith "TODO"
 
 let changes ?(until = "HEAD") r ~after = match r with
 | (`Git, _, _ as r) -> git_changes r ~after ~until

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -86,6 +86,8 @@ val describe : ?dirty:bool -> ?commit_ish:commit_ish -> t -> (string, R.msg) res
 val tags : t -> (string list, R.msg) result
 (** [tags r] is the list of tags in the repo [r]. *)
 
+val tag_exists: dry_run:bool -> t -> string -> bool
+
 val changes :
   ?until:commit_ish -> t -> after:commit_ish -> ((string * string) list, R.msg) result
 (** [changes r ~after ~until] is the list of commits with their


### PR DESCRIPTION
Instead, just force-push the latest tag to the dev-repo. Force-pushing
is probably not what we want here, but that's already an improvement.