### PR TITLE
Use '-p' instead of '-n' to follow dune conventions

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -17,7 +17,7 @@ let pkg_name =
              by the package description."
   in
   let docv = "PKG_NAME" in
-  Arg.(value & opt (some string) None & info ["n"; "pkg-name"] ~doc ~docv)
+  Arg.(value & opt (some string) None & info ["p"; "pkg-name"] ~doc ~docv)
 
 let opam =
   let doc = "The opam file to use. If absent uses the default opam file

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -285,7 +285,7 @@ let pkg_names =
              by the package description."
   in
   let docv = "PKG_NAME" in
-  Arg.(value & opt (list string) [] & info ["n"; "pkg-names"] ~doc ~docv)
+  Arg.(value & opt (list string) [] & info ["p"; "pkg-names"] ~doc ~docv)
 
 let man_xrefs = [`Main; `Cmd "distrib" ]
 let man =

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -301,7 +301,7 @@ let infer_name () =
     then shortest
     else begin
       Logs.err (fun m ->
-          m "cannot determine name automatically. Use `-n <name>`");
+          m "cannot determine name automatically. Use `-p <name>`");
       exit 1
     end
   in


### PR DESCRIPTION
This reverts e4bd7ad. The change is safe to do now as their is no
'browse' command anymore.