### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -266,7 +266,7 @@ let infer_name () =
     then shortest
     else begin
       Logs.err (fun m ->
-          m "cannot determine name automatically. Use `-p <name>`");
+          m "cannot determine name automatically. Use `-n <name>`");
       exit 1
     end
   in


### PR DESCRIPTION
-p no longer exists. The option was renamed to -n

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>