### PR TITLE
Remove short option p of opam sub command line (conflict)

### DIFF
--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -290,7 +290,7 @@ let pkg_names =
              by the package description."
   in
   let docv = "PKG_NAME" in
-  Arg.(value & opt (list string) [] & info ["p"; "pkg-names"] ~doc ~docv)
+  Arg.(value & opt (list string) [] & info ["pkg-names"] ~doc ~docv)
 
 let man_xrefs = [`Main; `Cmd "distrib" ]
 let man =


### PR DESCRIPTION
Got an `Invalid_argument` when `-p` is defined two times on the `opam` sub-command line.