### PR TITLE
 Determine opam-repository fork user from URI

### DIFF
--- a/dune-release.opam
+++ b/dune-release.opam
@@ -12,6 +12,10 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 
+build-test: [
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
+]
+
 depends: [
   "jbuilder" {build}
   "fmt"
@@ -22,6 +26,7 @@ depends: [
   "rresult"
   "logs"
   "odoc"
+  "alcotest" {test}
 ]
 
 available: [

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -8,6 +8,12 @@
 
 open Bos_setup
 
+val user_from_remote : string -> string option
+(** [user_from_remote remote_uri] is the username in the github URI [remote_uri]
+    ie [user_from_remote_uri "git@github.com:username/repo.git"] is [Some "username"].
+    Returns [None] if [remote_uri] isn't in the expected format.
+*)
+
 (** {1 Publish} *)
 
 val publish_distrib :
@@ -26,7 +32,7 @@ val publish_in_git_branch :
 
 val open_pr:
   token:Fpath.t -> dry_run:bool ->
-  title:string -> user:string -> branch:string ->
+  title:string -> distrib_user:string -> user:string -> branch:string ->
   string -> ([`Url of string | `Already_exists], R.msg) result
 
 (*---------------------------------------------------------------------------

--- a/tests/jbuild
+++ b/tests/jbuild
@@ -1,0 +1,8 @@
+(alias
+ ((name runtest)
+  (deps (tests.exe))
+  (action (run ${<}))))
+
+(executable
+ ((name tests)
+  (libraries (dune-release alcotest))))

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -1,0 +1,23 @@
+let user_from_remote_test_case =
+  let test () =
+    let check repo_uri expected =
+      Alcotest.(check (option string))
+        repo_uri
+        expected
+        (Dune_release.Github.user_from_remote repo_uri)
+    in
+    check "git@github.com:username/repo.git" (Some "username");
+    check "git@github.com:user-name/repo.git" (Some "user-name");
+    check "git@github.com:user-name-123/repo.git" (Some "user-name-123");
+    check "git@github.com:123/repo.git" (Some "123");
+    check "wrong" None;
+    check "https://github.com/username/repo.git" None;
+    ()
+  in
+  ("user_from_remote", `Quick, test)
+
+let test_set =
+  ( "Github"
+  , [ user_from_remote_test_case
+    ]
+  )

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -1,0 +1,5 @@
+let () =
+  Alcotest.run
+    "dune-release"
+    [ Test_github.test_set
+    ]


### PR DESCRIPTION
# What's wrong

When running `dune-release opam submit`, the actual PR creation on `opam-repository` can fail due to an invalid `head` field in the API requests. As far as I understand, this appears to happen when the user or organisation owning the package repo differs from the `opam-repository` fork owner. See #60 for further details.

# The actual fix

Since `dune-release opam submit` knows the `opam-repository` fork URI, it can be used to determine the owner of the fork and pass it in the github API request instead of the package repository owner.

# Notes

This is a first draft, I mostly wanted to have your feedback on the fix.

I wasn't sure whether HTTP URIs should be supported along with SSH ones here but that should be fairly easy to add.

If the parsing of the URI fails it falls back to `user`.

You'll also note I added some tests in a separate commit.

Let me know what you think!

Thanks