### PR TITLE
Fix github url regexp

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -14,7 +14,9 @@ module D = struct
 end
 
 let user_from_remote remote_uri =
-  let ssh_uri_regexp = Re.Emacs.compile_pat "git@github\\.com:\\(.+\\)/.+\\.git" in
+  let ssh_uri_regexp =
+    Re.Emacs.compile_pat "git@github\\.com:\\(.+\\)/.+\\(\\.git\\)?"
+  in
   try
     let substrings = Re.exec ssh_uri_regexp remote_uri in
     Some (Re.Group.get substrings 1)

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -10,6 +10,11 @@ let user_from_remote_test_case =
     check "git@github.com:user-name/repo.git" (Some "user-name");
     check "git@github.com:user-name-123/repo.git" (Some "user-name-123");
     check "git@github.com:123/repo.git" (Some "123");
+    (* Same as above but without the .git part *)
+    check "git@github.com:username/repo" (Some "username");
+    check "git@github.com:user-name/repo" (Some "user-name");
+    check "git@github.com:user-name-123/repo" (Some "user-name-123");
+    check "git@github.com:123/repo" (Some "123");
     check "wrong" None;
     check "https://github.com/username/repo.git" None;
     ()


### PR DESCRIPTION
Accept urls without .git at the end