### PR TITLE
generate sha256 and sha512 checksums for release

### DIFF
--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -26,7 +26,6 @@ end
 
 let format_upgrade ~dry_run ~url ~opam_f pkg opam dir =
   let opam_t = OpamFile.OPAM.read_from_string opam in
-  let url = OpamFile.URL.read_from_string url in
   match OpamVersion.to_string (OpamFile.OPAM.opam_version opam_t) with
   | "2.0" ->
       let file x = OpamFile.make (OpamFilename.of_string (Fpath.to_string x)) in

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -25,6 +25,7 @@ depends: [
   "re"
   "opam-format"
   "opam-state"
+  "opam-core"
   "rresult"
   "logs"
   "odoc"

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name        dune_release)
  (public_name dune-release)
- (libraries   fmt bos opam-format rresult bos.setup))
+ (libraries   fmt bos opam-format opam-core rresult bos.setup))

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -87,12 +87,12 @@ module Url : sig
 
   (** {1:url Url file} *)
 
-  val v : uri:string -> checksum:string -> string
-  (** [v ~uri ~checksum] is an URL file for URI [uri] with
-      checksum [checksum]. *)
+  val v : uri:string -> file:string -> OpamFile.URL.t
+  (** [v ~uri ~file] is an URL file for URI [uri] with
+      checksums computes on [file]. *)
 
   val with_distrib_file :
-    dry_run:bool -> uri:string -> Fpath.t -> (string, R.msg) result
+    dry_run:bool -> uri:string -> Fpath.t -> (OpamFile.URL.t, R.msg) result
   (** [with_distrib_file ~uri f] is an URL file for URI [uri] with
       the checksum of file [f]. *)
 end


### PR DESCRIPTION
use opam-core for doing these operations. instead of generating an URL and
checksum string (and parse with OpamFile.URL.read_from_string), construct a
OpamFile.URL.t directly in Opam.URL.with_distrib_file.

since dune-release always generates opam2 files, I don't see any reason to embed the md5 checksum in there at all...