### PR TITLE
Fix publish doc when no doc directory is present on gh-pages

### DIFF
--- a/lib/sos.ml
+++ b/lib/sos.ml
@@ -198,3 +198,8 @@ let cp ~dry_run ~rec_ ~force ~src ~dst =
   in
   let cmd = Cmd.(base_cmd % p src % p dst) in
   run ~dry_run cmd
+
+let relativize ~src ~dst =
+  R.of_option
+    ~none:(fun () -> R.error_msgf "Could define path from %a to %a" Fpath.pp src Fpath.pp dst)
+    (Fpath.relativize ~root:src dst)

--- a/lib/sos.ml
+++ b/lib/sos.ml
@@ -187,3 +187,14 @@ let out y =
   match OS.Cmd.run_out Cmd.(v "true") |> OS.Cmd.out_string with
   | Ok (_, x) -> y, x
   | Error _   -> assert false
+
+let cp ~dry_run ~rec_ ~force ~src ~dst =
+  let base_cmd =
+    match rec_, force with
+    | true, true -> Cmd.(v "cp" % "-r" % "-f")
+    | true, _ -> Cmd.(v "cp" % "-r")
+    | _, true -> Cmd.(v "cp" % "-f")
+    | _, _ -> Cmd.v "cp"
+  in
+  let cmd = Cmd.(base_cmd % p src % p dst) in
+  run ~dry_run cmd

--- a/lib/sos.mli
+++ b/lib/sos.mli
@@ -65,3 +65,7 @@ val cp:
   src: Fpath.t ->
   dst: Fpath.t ->
   (unit, error) result
+
+(** [relativize ~src ~dst] return a relative path from [src] to [dst]. If such a path can't be
+    expressed, i.e. [srs] and [dst] don't have a common root, returns an error. *)
+val relativize: src: Fpath.t -> dst: Fpath.t -> (Fpath.t, error) result

--- a/lib/sos.mli
+++ b/lib/sos.mli
@@ -54,3 +54,14 @@ val file_must_exist: dry_run:bool -> Fpath.t -> (Fpath.t, error) result
 
 val out: 'a -> 'a * Bos.OS.Cmd.run_status
 val mkdir: dry_run:bool -> Fpath.t -> (bool, error) result
+
+(** [cp ~dry_run ~rec ~force ~src ~dst] copies [src] to [dst]. If [rec] is true, copies directories
+    recursively. If [force] is true, overwrite existing files. The usual [force] arguments from
+    other functions in this module is renamed [force_side_effects] here. *)
+val cp:
+  dry_run: bool ->
+  rec_: bool ->
+  force: bool ->
+  src: Fpath.t ->
+  dst: Fpath.t ->
+  (unit, error) result


### PR DESCRIPTION
I believe this should fix #117, and fix #114 as well.

What happened is that the hand-rolled `cp` function in `Github.publish_in_git_branch` would not work if the `doc/` directory did not already exists on the `gh-pages` branch and thus `dune-release publish doc` would fail when trying to release new packages.

See the `dune-release` logs (with a few extra debug prints of my own):
```
$ dune-release publish
fatal: Couldn't find remote ref gh-pages
Initialized empty Git repository in /tmp/gh-pages-ce3eac.tmp/.git/
Switched to a new branch 'gh-pages'
[gh-pages (root-commit) cd3c372] Initial commit by dune-release.
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 README
warning: no common commits
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0)
Unpacking objects: 100% (3/3), done.
From /tmp/gh-pages-ce3eac.tmp
 * branch            gh-pages   -> FETCH_HEAD
Branch 'gh-pages' set up to track remote branch 'gh-pages' from 'origin'.
Switched to a new branch 'gh-pages'
Deleting dir: doc
Current dir: /home/nathan/code/quick-dune-release-testing/_build/lol-v0.0.0/_build/gh-pages
Copying dir _build/lol-v0.0.0/_build/default/_doc/_html to doc
Current dir: /home/nathan/code/quick-dune-release-testing/_build/lol-v0.0.0/_build/gh-pages
copy_dir /home/nathan/code/quick-dune-release-testing/_build/lol-v0.0.0/_build/default/_doc/_html/ doc
Copying file /home/nathan/code/quick-dune-release-testing/_build/lol-v0.0.0/_build/default/_doc/_html/odoc.css to doc/odoc.css
read_file /home/nathan/code/quick-dune-release-testing/_build/lol-v0.0.0/_build/default/_doc/_html/odoc.css
write_file doc/odoc.css
dune-release: [ERROR] create temporary file doc/bos-656566.tmp: No such file
                      or directory
```

I encountered this issue a few times myself.

This PR replace the custom `cp` function by a `Sos.cp` one which just calls Unix's `cp`. Note that I'm happy to re-write a custom `cp` in `Sos` if there's a portability issue but considering `bos` depends on OCaml's `Unix` I thought it wouldn't be a problem.
For this to work it requires to pass correct relative paths which I achieved by using `Fpath.relativize`.

The current state is not perfectly satisfactory but it seems to work. I tested it on https://github.com/NathanReb/dune-release-testing (feel free to clone it and try to reproduce).

This whole part of the code seems pretty fragile and I'm happy to work on further refactoring it in separate PRs.