### PR TITLE
Move Styled_pp to Text.Pp

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -275,20 +275,20 @@ let publish_distrib ~dry_run ~msg ~archive p =
   >>= fun tag -> check_tag ~dry_run vcs tag
   >>= fun () -> dev_repo p
   >>= fun upstr ->
-  Logs.app (fun l -> l "Pushing tag %a to %a" Styled_pp.tag tag Styled_pp.url upstr);
+  Logs.app (fun l -> l "Pushing tag %a to %a" Text.Pp.version tag Text.Pp.url upstr);
   Sos.run_quiet ~dry_run Cmd.(git % "push" % "--force" % upstr % tag)
   >>= fun () -> Config.token ~dry_run ()
   >>= fun token ->
   Logs.app
-    (fun l -> l "Creating release %a on %a through github's API" Styled_pp.tag tag Styled_pp.url upstr);
+    (fun l -> l "Creating release %a on %a through github's API" Text.Pp.version tag Text.Pp.url upstr);
   curl_create_release ~token ~dry_run curl tag msg user repo
   >>= fun id ->
   Logs.app (fun l -> l "Succesfully created release with id %d" id);
   Logs.app
     (fun l -> l "Uploading %a as a release asset for %a through github's API"
-        Styled_pp.archive
+        Text.Pp.path
         archive
-        Styled_pp.tag
+        Text.Pp.version
         tag);
   curl_upload_archive ~token ~dry_run curl archive user repo id
 

--- a/lib/styled_pp.ml
+++ b/lib/styled_pp.ml
@@ -1,4 +1,0 @@
-let tag = Fmt.(styled `Cyan string)
-let archive = Fmt.(styled `Bold Fpath.pp)
-let url = Fmt.(styled `Underline string)
-let package = Fmt.(styled `Bold string)

--- a/lib/styled_pp.mli
+++ b/lib/styled_pp.mli
@@ -1,7 +1,0 @@
-val tag : string Fmt.t
-
-val url : string Fmt.t
-
-val archive : Fpath.t Fmt.t
-
-val package : string Fmt.t

--- a/lib/text.ml
+++ b/lib/text.ml
@@ -161,6 +161,7 @@ module Pp = struct
   let commit = Fmt.(styled `Yellow string)
   let dirty = Fmt.(styled_unit `Red "dirty")
   let path = Fmt.(styled `Bold Fpath.pp)
+  let url = Fmt.(styled `Underline string)
   let status ppf = function
   | `Ok -> Fmt.(brackets @@ styled_unit `Green " OK ") ppf ()
   | `Fail -> Fmt.(brackets @@ styled_unit `Red "FAIL") ppf ()

--- a/lib/text.mli
+++ b/lib/text.mli
@@ -97,6 +97,9 @@ module Pp : sig
   val path : Fpath.t Fmt.t
   (** [path] formats a bold path *)
 
+  val url : string Fmt.t
+  (** [url] formats an underlined URL *)
+
   val status : [`Ok | `Fail] Fmt.t
   (** [status] formats a result status. *)
 end


### PR DESCRIPTION
Missed that module during my previous work on the `publish` command logs but that's where other such formatters are defined.