### PR TITLE
Allow to submit packages to a different opam repo on github

### DIFF
--- a/lib/github.mli
+++ b/lib/github.mli
@@ -41,6 +41,7 @@ val publish_in_git_branch :
 val open_pr:
   token:Fpath.t -> dry_run:bool ->
   title:string -> distrib_user:string -> user:string -> branch:string ->
+  opam_repo: (string * string) ->
   string -> ([`Url of string | `Already_exists], R.msg) result
 
 (*---------------------------------------------------------------------------

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -45,7 +45,7 @@ let cmd = Cmd.of_list @@ Cmd.to_list @@ tool "opam" `Host_os
 let shortest x =
   List.hd (List.sort (fun x y -> compare (String.length x) (String.length y)) x)
 
-let prepare ~dry_run ?msg ~local_repo ~remote_repo ~version names =
+let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
   let msg = match msg with
   | None -> Ok (Cmd.empty)
   | Some msg ->
@@ -63,7 +63,10 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~version names =
   let git_for_repo r = Cmd.of_list (Cmd.to_list @@ Vcs.cmd r) in
   Vcs.get () >>= fun repo ->
   let git = git_for_repo repo in
-  let upstream = "https://github.com/ocaml/opam-repository.git" in
+  let upstream =
+    let user, repo = opam_repo in
+    Printf.sprintf "https://github.com/%s/%s.git" user repo
+  in
   let remote_branch = "master" in
   let pkg = shortest names in
   let branch = Fmt.strf "release-%s-%s" pkg version in

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -17,6 +17,7 @@ val cmd : Cmd.t
 
 val prepare : dry_run:bool -> ?msg:string ->
   local_repo:Fpath.t -> remote_repo:string ->
+  opam_repo: (string * string) ->
   version:string -> string list -> (string, R.msg) result
 (** [prepare ~local_repo ~version pkgs] adds the packages
    [pkg.version] to a new branch in the local opam repository


### PR DESCRIPTION
I'm not sure this should be merged but it is really convenient for testing. I guess it could be useful for people maintaining custom opam repositories as well.

Let me know what you think!