### PR TITLE
Prompt user for confirmation during tag command

### DIFF
--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -11,8 +11,14 @@ let vcs_tag tag ~dry_run ~commit_ish ~force ~sign ~delete ~msg =
   let msg = match msg with None -> strf "Distribution %s" tag | Some m -> m in
   Vcs.get ()
   >>= fun repo -> match delete with
-  | true -> Vcs.delete_tag ~dry_run repo tag
+  | true ->
+      Prompt.confirm_or_abort
+        ~question:(fun l -> l "Delete tag %a?" Text.Pp.version tag) >>= fun () ->
+      Vcs.delete_tag ~dry_run repo tag
   | false ->
+      Prompt.confirm_or_abort
+        ~question:(fun l -> l "Create git tag %a for %a?" Text.Pp.version tag Text.Pp.commit commit_ish)
+      >>= fun () ->
       Vcs.tag repo ~dry_run ~force ~sign ~msg ~commit_ish tag >>| fun () ->
       Logs.app (fun m -> m "Tagged %a with version %a" Text.Pp.commit commit_ish Text.Pp.version tag)
 

--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -14,7 +14,7 @@ let vcs_tag tag ~dry_run ~commit_ish ~force ~sign ~delete ~msg =
   | true -> Vcs.delete_tag ~dry_run repo tag
   | false ->
       Vcs.tag repo ~dry_run ~force ~sign ~msg ~commit_ish tag >>| fun () ->
-      Logs.app (fun m -> m "Tagged %s with version %a" commit_ish Text.Pp.version tag)
+      Logs.app (fun m -> m "Tagged %a with version %a" Text.Pp.commit commit_ish Text.Pp.version tag)
 
 let tag () dry_run name change_log tag commit_ish force sign delete msg =
   begin
@@ -25,7 +25,7 @@ let tag () dry_run name change_log tag commit_ish force sign delete msg =
         Ok t
     | None   ->
         Pkg.change_log pkg >>= fun changelog ->
-        Logs.app (fun l -> l "Extracting tag from first entry in %a" Fpath.pp changelog);
+        Logs.app (fun l -> l "Extracting tag from first entry in %a" Text.Pp.path (Fpath.normalize changelog));
         Pkg.extract_tag pkg >>| fun t ->
         Logs.app (fun l -> l "Using tag %S" t);
         t

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1,0 +1,22 @@
+let ask f =
+  Logs.app (fun l -> f (fun ?header ?tags fmt -> l ?header ?tags (fmt ^^ " [Y/n]")))
+
+let confirm ~question =
+  let rec loop () =
+    ask question;
+    match String.lowercase_ascii (read_line ()) with
+    | "" | "y" | "yes" -> true
+    | "n" | "no" -> false
+    | _ ->
+        Logs.app
+          (fun l ->
+             l "Please answer with \"y\" for yes, \"n\" for no or just hit enter for the default");
+        loop ()
+  in
+  loop ()
+
+let confirm_or_abort ~question =
+  if confirm ~question then
+    Ok ()
+  else
+    Error (`Msg "Aborting on user demand")

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1,7 +1,7 @@
 let ask f =
   Logs.app (fun l -> f (fun ?header ?tags fmt -> l ?header ?tags (fmt ^^ " [Y/n]")))
 
-let confirm ~question =
+let confirm ~question ~yes =
   let rec loop () =
     ask question;
     match String.lowercase_ascii (read_line ()) with
@@ -13,10 +13,10 @@ let confirm ~question =
              l "Please answer with \"y\" for yes, \"n\" for no or just hit enter for the default");
         loop ()
   in
-  loop ()
+  if not yes then loop () else true
 
-let confirm_or_abort ~question =
-  if confirm ~question then
+let confirm_or_abort ~question ~yes =
+  if confirm ~question ~yes then
     Ok ()
   else
     Error (`Msg "Aborting on user demand")

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -1,10 +1,17 @@
 (** Promtps the user for confirmation.
-    [confirm ~question] uses the message formatting function [question] to format and log
+    [confirm ~question ~yes] uses the message formatting function [question] to format and log
     a message with the app level and wait for a yes or no answer from the user.
     Returns [true] for yes. Defaults to yes if the user just press enter.
+    If [yes] then just skip the prompt and returns [true].
     E.g. [confirm ~question:(fun l -> l "Do you want some %a?" Fmt.(styled `Bold string) "coffee")] *)
-val confirm : question: ('a, unit) Logs.msgf -> bool
+val confirm :
+  question: ('a, unit) Logs.msgf ->
+  yes: bool ->
+  bool
 
 (** Same as [confirm] but returns [Ok ()] for yes and [Error (`Msg "Aborting on user demand")] for
     no *)
-val confirm_or_abort : question: ('a, unit) Logs.msgf -> (unit, Rresult.R.msg) result
+val confirm_or_abort :
+  question: ('a, unit) Logs.msgf ->
+  yes: bool ->
+  (unit, Rresult.R.msg) result

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -1,0 +1,10 @@
+(** Promtps the user for confirmation.
+    [confirm ~question] uses the message formatting function [question] to format and log
+    a message with the app level and wait for a yes or no answer from the user.
+    Returns [true] for yes. Defaults to yes if the user just press enter.
+    E.g. [confirm ~question:(fun l -> l "Do you want some %a?" Fmt.(styled `Bold string) "coffee")] *)
+val confirm : question: ('a, unit) Logs.msgf -> bool
+
+(** Same as [confirm] but returns [Ok ()] for yes and [Error (`Msg "Aborting on user demand")] for
+    no *)
+val confirm_or_abort : question: ('a, unit) Logs.msgf -> (unit, Rresult.R.msg) result


### PR DESCRIPTION
We now ask for confirmation before creating or deleting the tag when running `dune-release tag`.

Such prompts can be skipped by passing the `-y/--yes` flag on the command line.

If this looks good to you I'll add other such prompts and CLI flags elsewhere. As a rule of thumb I'd say we should ask for confirmation before any modification of the local git tree or the remote github repo. From the top of my head that would include:
- Pushing to the gh-pages branch
- Pushing tags
- Creating a release through the github API
- Uploading an archive through the github API
- Opening a PR to the opam repository through github API

I think all the rest is done either in a tmp dir or the _build dir but I might have missed something.

Let me know what you think!