### PR TITLE
Fix documentation publication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## unreleased
+
+- Fix a bug in documentation publication where under certain circumstances the
+  doc would be published in a `_html` folder instead of being published at the
+  root of `gh-pages` (#157, @NathanReb)
+
 ## 1.3.0 (2019-05-29)
 
 - Add confirmation prompts in some commands. (#144, #146, @NathanReb)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -67,7 +67,7 @@ let publish_in_git_branch ~dry_run ~remote ~branch ~name ~version ~docdir ~dir ~
     >>= fun git ->
     Sos.run_quiet ~dry_run ~force:(dir <> D.dir) Cmd.(git % "checkout" % branch)
     >>= fun () -> delete dir
-    >>= fun () -> Sos.cp ~dry_run ~rec_:true ~force:true ~src:docdir ~dst:dir
+    >>= fun () -> Sos.cp ~dry_run ~rec_:true ~force:true ~src:Fpath.(docdir / ".") ~dst:dir
     >>= fun () -> (if dry_run then Ok true else Vcs.is_dirty repo)
     >>= function
     | false -> Ok false


### PR DESCRIPTION
Fixes #155 or to be precise, fixes the bug that lead to the missing documentation. I will release a patch and a new documentation once this gets merged.

When I replaced the hand-rolled `cp` code in documentation publication I did not account for different `cp` behaviours depending on the existence of the destination directory. That means that when one wants to publish to the root of its gh-pages, the `_html` dir was copied as is in there instead of its content because the root of the gh-pages temporary project exists. This bug wasn't triggered during my tests because I published the doc in a `doc` sub dir.