### PR TITLE
Distinguish logs with a header

### DIFF
--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -16,26 +16,26 @@ let gen_doc ~dry_run ~force dir pkg_names =
   Ok Fpath.(dir // doc_dir)
 
 let publish_doc ~dry_run ~yes pkg_names pkg =
-  Logs.app (fun l -> l "Publishing documentation");
+  App_log.status (fun l -> l "Publishing documentation");
   Pkg.distrib_file ~dry_run pkg
   >>= fun archive -> Pkg.publish_msg pkg
   >>= fun msg -> Archive.untbz ~dry_run ~clean:true archive
   >>= fun dir -> OS.Dir.exists dir
   >>= fun force -> Pkg.infer_pkg_names dir pkg_names
   >>= fun pkg_names ->
-  Logs.app (fun l -> l "Selected packages: %a" Fmt.(list (styled `Bold string)) pkg_names);
-  Logs.app (fun l -> l "Generating documentation from %a" Text.Pp.path archive);
+  App_log.status (fun l -> l "Selected packages: %a" Fmt.(list (styled `Bold string)) pkg_names);
+  App_log.status (fun l -> l "Generating documentation from %a" Text.Pp.path archive);
   gen_doc ~dry_run ~force dir pkg_names
   >>= fun docdir -> Delegate.publish_doc ~dry_run ~yes pkg ~msg ~docdir
 
 let publish_distrib ~dry_run ~yes pkg =
-  Logs.app (fun l -> l "Publishing distribution");
+  App_log.status (fun l -> l "Publishing distribution");
   Pkg.distrib_file ~dry_run pkg
   >>= fun archive -> Pkg.publish_msg pkg
   >>= fun msg     -> Delegate.publish_distrib ~dry_run ~yes pkg ~msg ~archive
 
 let publish_alt ~dry_run pkg kind =
-  Logs.app (fun l -> l "Publishing %s" kind);
+  App_log.status (fun l -> l "Publishing %s" kind);
   Pkg.distrib_file ~dry_run pkg
   >>= fun archive -> Pkg.publish_msg pkg
   >>= fun msg     -> Delegate.publish_alt ~dry_run pkg ~kind ~msg ~archive

--- a/lib/app_log.ml
+++ b/lib/app_log.ml
@@ -1,0 +1,18 @@
+let header style c =
+  fun fmt () ->
+  Fmt.string fmt "[";
+  Fmt.(styled style (const char c)) fmt ();
+  Fmt.string fmt "]"
+
+let app_log ?src pp_header f =
+  Logs.app ?src (fun l -> f (fun ?header ?tags fmt -> l ?header ?tags ("%a " ^^ fmt) pp_header ()))
+
+let status ?src f = app_log ?src (header `Yellow '-') f
+
+let question ?src f = app_log ?src (header `Magenta '?') f
+
+let success ?src f = app_log ?src (header `Green '+') f
+
+let unhappy ?src f = app_log ?src (header `Red '!') f
+
+let blank_line () = Logs.app (fun l -> l "");

--- a/lib/app_log.mli
+++ b/lib/app_log.mli
@@ -1,0 +1,16 @@
+(** App level logs with distinct headers based on the nature of the message *)
+
+(** For informative messages about what's currently happening such as ["doing this"] *)
+val status : ?src: Logs.src -> 'a Logs.log
+
+(** For prompts *)
+val question : ?src: Logs.src -> 'a Logs.log
+
+(** To report successfully completed tasks *)
+val success : ?src: Logs.src -> 'a Logs.log
+
+(** To report something that went wrong but isn't worth a warning *)
+val unhappy : ?src: Logs.src -> 'a Logs.log
+
+(** Outpus an empty line *)
+val blank_line : unit -> unit

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -119,9 +119,8 @@ let config_dir () =
     OS.Dir.exists old_d >>= function
     | false -> Ok ()
     | true  ->
-        Logs.app (fun m ->
-            m "Upgrading configuration files: %a => %a"
-              Fpath.pp old_d Fpath.pp cfg);
+        App_log.status
+          (fun m -> m "Upgrading configuration files: %a => %a" Fpath.pp old_d Fpath.pp cfg);
         OS.Dir.create ~path:true cfg >>= fun _ ->
         OS.Path.move old_d Fpath.(cfg / "release.yml")
   in

--- a/lib/delegate.ml
+++ b/lib/delegate.ml
@@ -22,13 +22,13 @@ let run_delegate ~dry_run del args =
 let publish_distrib ~dry_run ~msg ~archive ~yes pkg =
   Pkg.delegate pkg >>= function
   | None     ->
-      Logs.app (fun l -> l "Publishing to github");
+      App_log.status (fun l -> l "Publishing to github");
       Github.publish_distrib ~dry_run ~yes ~msg ~archive pkg >>= fun url ->
       Pkg.archive_url_path pkg >>= fun url_file ->
       Sos.write_file ~dry_run url_file url >>= fun () ->
       Ok ()
   | Some del ->
-      Logs.app (fun l -> l "Using delegate %a" Cmd.pp del);
+      App_log.status (fun l -> l "Using delegate %a" Cmd.pp del);
       Pkg.name pkg
       >>= fun name -> Pkg.tag pkg
       >>= fun version -> Pkg.distrib_uri pkg
@@ -40,10 +40,10 @@ let publish_distrib ~dry_run ~msg ~archive ~yes pkg =
 let publish_doc ~dry_run ~msg ~docdir ~yes p =
   Pkg.delegate p >>= function
   | None     ->
-      Logs.app (fun l -> l "Publishing to github");
+      App_log.status (fun l -> l "Publishing to github");
       Github.publish_doc ~dry_run ~msg ~docdir ~yes p
   | Some del ->
-      Logs.app (fun l -> l "Using delegate %a" Cmd.pp del);
+      App_log.status (fun l -> l "Using delegate %a" Cmd.pp del);
       let doc_uri p = Pkg.opam_field_hd p "doc" >>= function
         | None -> Ok ""
         | Some uri -> Ok uri
@@ -60,7 +60,7 @@ let publish_alt ~dry_run ~kind ~msg ~archive p =
   Pkg.delegate p >>= function
   | None     -> R.error_msgf "No default delegate to publish %s" kind
   | Some del ->
-      Logs.app (fun l -> l "Using delegate %a" Cmd.pp del);
+      App_log.status (fun l -> l "Using delegate %a" Cmd.pp del);
       Pkg.name p
       >>= fun name -> Pkg.version p
       >>= fun version -> Pkg.distrib_uri p

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -153,7 +153,7 @@ let lint_opam ~dry_run pkg =
   Pkg.opam_field_hd pkg "opam-version" >>= fun opam_file_version ->
   match opam_file_version, opam_tool_version with
   | Some "2.0", `v1_2_2 ->
-      Logs.app
+      App_log.status
         (fun l ->
            l "Skipping opam lint as `opam-version` field is \"2.0\" while `opam --version` is 1.2.2");
       Ok 0

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -74,7 +74,7 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
   let run_out = Sos.run_out ~sandbox:false ~dry_run ~force:true in
   let prepare_repo () =
     let git_fetch = Cmd.(git % "fetch" % upstream % remote_branch) in
-    Logs.app (fun l -> l "Fetching %a" Text.Pp.url (upstream ^ "#" ^ remote_branch));
+    App_log.status (fun l -> l "Fetching %a" Text.Pp.url (upstream ^ "#" ^ remote_branch));
     run git_fetch >>= fun () ->
     run_out Cmd.(git % "rev-parse" % "FETCH_HEAD")
       ~default:"${fetch_head}" OS.Cmd.to_string
@@ -93,7 +93,7 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
       )
     in
     delete_branch () >>= fun () ->
-    Logs.app (fun l -> l "Checking out a local %a branch" Text.Pp.commit branch);
+    App_log.status (fun l -> l "Checking out a local %a branch" Text.Pp.commit branch);
     Vcs.checkout repo ~dry_run:false ~branch ~commit_ish:id
   in
   OS.Dir.current () >>= fun cwd ->
@@ -127,7 +127,7 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
   in
   let commit_and_push () =
     Sos.run_quiet ~dry_run ~sandbox:false Cmd.(git % "commit" %% msg) >>= fun () ->
-    Logs.app (fun l -> l "Pushing %a to %a" Text.Pp.commit branch Text.Pp.url remote_repo);
+    App_log.status (fun l -> l "Pushing %a to %a" Text.Pp.commit branch Text.Pp.url remote_repo);
     Sos.run_quiet ~dry_run ~sandbox:false Cmd.(git % "push" % "--force" % remote_repo % branch)
   in
   Sos.with_dir ~dry_run local_repo (fun () ->

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1,5 +1,5 @@
 let ask f =
-  Logs.app (fun l -> f (fun ?header ?tags fmt -> l ?header ?tags (fmt ^^ " [Y/n]")))
+  App_log.question (fun l -> f (fun ?header ?tags fmt -> l ?header ?tags (fmt ^^ " [Y/n]")))
 
 let confirm ~question ~yes =
   let rec loop () =
@@ -8,7 +8,7 @@ let confirm ~question ~yes =
     | "" | "y" | "yes" -> true
     | "n" | "no" -> false
     | _ ->
-        Logs.app
+        App_log.unhappy
           (fun l ->
              l "Please answer with \"y\" for yes, \"n\" for no or just hit enter for the default");
         loop ()


### PR DESCRIPTION
This fixes #159.

App level logs now go through an `App_log` module which puts headers in front of logs based on their status.

Here is an example output:
![Screenshot from 2019-07-04 19-51-31](https://user-images.githubusercontent.com/7419360/60707644-81589180-9f0c-11e9-8267-104f31cdbc0a.png)

It's not so obvious without the colors but I personally tend to look at the left of the screen and it should still be more noticeable than it used to.
```
$ dune-release publish
[-] Publishing documentation
[-] Selected packages: dummy
[-] Generating documentation from _build/dummy-v0.2.0+test.tbz
[-] Publishing to github
[-] Updating local gh-pages branch
[+] No documentation changes for dummy 0.2.0+test in directory . of gh-pages branch
[-] Publishing distribution
[-] Publishing to github
[?] Push tag v0.2.0+test to git@github.com:NathanReb/dune-release-testing.git? [Y/n]
```