### PR TITLE
Make description optional for opam submit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## unreleased
+
+### Fixed
+
+- Fix a bug where `opam submit` would fail if the opam files had no description
+  (#165, @NathanReb)
+
 ## 1.3.2 (2019-07-12)
 
 ### Fixed

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -62,7 +62,7 @@ module Descr : sig
 
   (** {1:descr Descr file} *)
 
-  type t = string * string
+  type t = string * string option
   (** The type for opam [descr] files, the package synopsis and the
       description. *)
 

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -159,10 +159,9 @@ let opam_descr p =
       | Some "2.0" -> (
           opam_field_hd p "synopsis" >>= fun s ->
           opam_field_hd p "description" >>= fun d ->
-          match s, d with
-          | Some s, Some d -> Ok (s, d)
-          | None  , _ -> R.error_msgf "missing synopsis"
-          | _, None   -> R.error_msgf "missing description"
+          match s with
+          | Some s -> Ok (s, d)
+          | None -> R.error_msgf "missing synopsis"
         )
       | Some ("1.2" | "1.0") -> (
           let descr_file = descr_file_for_opam opam in


### PR DESCRIPTION
Fixes #164

This makes the description field optional when submitting a PR to opam-repository.

Given that opam considers it okay as long as there's a synopsis I think it make sense to allow a missing description field. We might even consider make that just a warning in the lint phase as well but that's a separate matter I'd say. The important is that it doesn't prevent one from releasing!