### PR TITLE
Fix a bug in opam file transformation for distrib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Fix a bug where `opam submit` would fail if the opam files had no description
   (#165, @NathanReb)
+- Fix a bug where opam files could be inproperly tempered with while building
+  the distribution tarball (#168, @NathanReb)
 
 ## 1.3.2 (2019-07-12)
 

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 1.2)
 (name dune-release)

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {>= "1.2.0"}
   "fmt"
   "bos"
   "cmdliner"

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -154,6 +154,14 @@ val extract_tag : t -> (string, Sos.error) result
 
 val dev_repo : t -> (string option, Sos.error) result
 
+(**/**)
+
+val version_line_re : Re.t
+
+val prepare_opam_for_distrib : version: string -> content: string list -> string list
+
+(**/**)
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,4 @@
 (test
  (name tests)
- (libraries dune-release alcotest))
+ (libraries dune-release alcotest)
+ (action (run %{test} -e)))

--- a/tests/test_pkg.ml
+++ b/tests/test_pkg.ml
@@ -1,0 +1,58 @@
+let test_version_line_re =
+  let make_test ~input ~expected =
+    let test_name =
+      if expected then
+        input ^ "is a valid version field line"
+      else
+        input ^ "is not a valid version field line"
+    in
+    let test_fun () =
+      let re = Re.compile Dune_release.Pkg.version_line_re in
+      let actual = Re.execp re input in
+      Alcotest.(check bool) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [ make_test ~input:"" ~expected:false
+  ; make_test ~input:{|version:""|} ~expected:false
+  ; make_test ~input:{|version:"1"|} ~expected:true
+  ; make_test ~input:{|version:     "1"    |} ~expected:true
+  ; make_test ~input:{|version:"1.jfpojef.adp921709"|} ~expected:true
+  ]
+
+let test_prepare_opam_for_distrib =
+  let make_test ~name ~version ~content ~expected () =
+    let test_name = "prepare_opam_for_distrib: " ^ name in
+    let test_fun () =
+      let actual = Dune_release.Pkg.prepare_opam_for_distrib ~version ~content in
+      Alcotest.(check (list string)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [ make_test ~name:"empty" ~content:[] ~version:"1" ~expected:[{|version: "1"|}] ()
+  ; make_test
+      ~name:"replace version"
+      ~content:[{|version: "1"|}]
+      ~version:"2"
+      ~expected:[{|version: "2"|}]
+      ()
+  ; make_test
+      ~name:"only replace version field"
+      ~content:
+        [ {|version: "1"|}
+        ; {|description: """|}
+        ; {|version: "1" blablabla|}
+        ; {|"""|}
+        ]
+      ~version:"2"
+      ~expected:
+        [ {|version: "2"|}
+        ; {|description: """|}
+        ; {|version: "1" blablabla|}
+        ; {|"""|}
+        ]
+      ()
+  ]
+
+let suite =
+  ("Pkg", test_version_line_re @ test_prepare_opam_for_distrib)

--- a/tests/test_pkg.mli
+++ b/tests/test_pkg.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest.test

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -1,5 +1,6 @@
 let () =
   Alcotest.run "dune-release" [
     Test_github.suite;
+    Test_pkg.suite;
     Test_tags.suite;
   ]


### PR DESCRIPTION
Fixes #163 

The code that adds the version to the opam file before building the distrib tarball was a bit lax and in some cases (like in #163) it would filter out lines that weren't actually the version field line.

This PR adds a few tests and strengthen that part of the code a bit.

The proper fix would probably be to use opam's libary for that but I think a quick fix will do for now. We won't need to do this anymore when integrating into dune!