### PR TITLE
Streamline the error handling in archive.ml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 ### Fixed
 
 - Separate packages names by spaces in `publish` logs (#171, @hannesm)
+- Fix uncaught exceptions in distrib subcommand and replace them with proper
+  error messages (#176, @gpetiot)
 
 ### Removed
 

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -1,0 +1,13 @@
+open Bos_setup
+
+module Sbytes = struct
+  type t = Bytes.t
+
+  let make size char =
+    try R.ok (Bytes.make size char)
+    with Invalid_argument e -> R.error_msg e
+
+  let blit_string src srcoff dst dstoff len =
+    try R.ok (Bytes.blit_string src srcoff dst dstoff len)
+    with Invalid_argument e -> R.error_msg e
+end

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -1,0 +1,20 @@
+open Bos_setup
+
+(** Safe wrapping for some Bytes functions. *)
+module Sbytes : sig
+  type t = Bytes.t
+  (** An alias for the type of byte sequences. *)
+
+  val make : int -> char -> (t, [> R.msg]) result
+  (** [make n c] returns a new byte sequence of length [n], filled with the
+      byte [c].
+      Returns an error message if [n < 0] or [n > Sys.max_string_length]. *)
+
+  val blit_string : string -> int -> t -> int -> int -> (unit, [> R.msg]) result
+  (** [blit src srcoff dst dstoff len] copies [len] bytes from string [src],
+      starting at index [srcoff], to byte sequence [dst], starting at index
+      [dstoff].
+      Returns an error message if [srcoff] and [len] do not designate a valid
+      range of [src], or if [dstoff] and [len] do not designate a valid range of
+      [dst]. *)
+end


### PR DESCRIPTION
- replace the exceptions with error types in archive.ml
- defining a `Sbytes` module to wrap 2 unsafe functions of `Bytes`
- minor style changes (put the infix operator and the anonymous function argument at the end of the line) (applying ocamlformat would generate a huge diff for now)