### PR TITLE
Use the 'user' field in the configuration before inferring it from repo URI and handles HTTPS URIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 - Separate packages names by spaces in `publish` logs (#171, @hannesm)
 - Fix uncaught exceptions in distrib subcommand and replace them with proper
   error messages (#176, @gpetiot)
+- Use the 'user' field in the configuration before inferring it from repo URI
+  and handles HTTPS URIs (#183, @gpetiot)
 
 ### Removed
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -10,9 +10,13 @@ open Bos_setup
 
 module Parse : sig
   val user_from_remote : string -> string option
-  (** [user_from_remote remote_uri] is the username in the github URI [remote_uri]
-      ie [user_from_remote_uri "git@github.com:username/repo.git"] is [Some "username"].
-      Returns [None] if [remote_uri] isn't in the expected format.
+  (** [user_from_remote remote_uri] is the username in the github URI [remote_uri], ie:
+
+      - [user_from_remote_uri "git@github.com:username/repo.git"] returns
+        [Some "username"]
+      - [user_from_remote_uri "https://github.com/username/repo.git"] returns
+        [Some "username"].
+      - Returns [None] if [remote_uri] isn't in the expected format.
   *)
 
   val archive_upload_url : string -> (string, R.msg) Result.result

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -15,7 +15,7 @@ let user_from_remote () =
   check "git@github.com:user-name-123/repo" (Some "user-name-123");
   check "git@github.com:123/repo" (Some "123");
   check "wrong" None;
-  check "https://github.com/username/repo.git" None
+  check "https://github.com/username/repo.git" (Some "username")
 
 let archive_upload_url () =
   let check response expected =


### PR DESCRIPTION
Should fix #173 

- using the `user` field of the `.yaml` configuration file as the first choice, and then trying to deduce it from URI if it is not set in the configuration file.
- handling HTTPS in addition to SSH URIs