### PR TITLE
Improve the output of VCS command errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Ignore backup files when looking for README, CHANGES and LICENSE files
   (#194, @gpetiot)
 - Do not echo input characters when reading token (#199, @gpetiot)
+- Improve the output of VCS command errors (#193, @gpetiot)
 
 ### Removed
 

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -37,6 +37,10 @@ val cmd : t -> Bos.Cmd.t
 
     {b Warning} Prefer the functions below to remain VCS independent. *)
 
+val cmd_error : Bos.Cmd.t -> Bos.OS.Cmd.status -> ('a, R.msg) result
+(** [cmd_error cmd status] returns an error message describing the failing
+    command [cmd] and the exit status [status]. *)
+
 val find : ?dir:Fpath.t -> unit -> (t option, R.msg) result
 (** [find ~dir ()] looks for a VCS repository in working directory [dir] (not
     the repository directory like [.git], default is guessed automatically). *)

--- a/tests/test_vcs.ml
+++ b/tests/test_vcs.ml
@@ -1,0 +1,22 @@
+let cmd_error () =
+  let check ~name ~cmd ~status ~expected =
+    let name = "cmd_error: " ^ name in
+    match Dune_release.Vcs.cmd_error cmd status with
+    | Ok _ -> Alcotest.fail name (* Vcs.cmd_error always returns an Error *)
+    | Error (`Msg e) -> Alcotest.(check string) name expected e
+  in
+  let cmd =
+    Bos_setup.Cmd.(
+      v "git" % "--git-dir" % ".git" % "--work-tree" % "." % "diff-index"
+      % "--quiet" % "HEAD")
+  in
+  check ~name:"cmd exited" ~cmd ~status:(`Exited 2)
+    ~expected:
+      "The following command exited with code 2:\n\
+       git --git-dir .git --work-tree . diff-index --quiet HEAD";
+  check ~name:"cmd signaled" ~cmd ~status:(`Signaled 3)
+    ~expected:
+      "The following command exited with signal 3:\n\
+       git --git-dir .git --work-tree . diff-index --quiet HEAD"
+
+let suite = ("Vcs", [ ("cmd_error", `Quick, cmd_error) ])

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -1,3 +1,9 @@
 let () =
   Alcotest.run "dune-release"
-    [ Test_github.suite; Test_pkg.suite; Test_stdext.suite; Test_tags.suite ]
+    [
+      Test_github.suite;
+      Test_pkg.suite;
+      Test_stdext.suite;
+      Test_tags.suite;
+      Test_vcs.suite;
+    ]


### PR DESCRIPTION
Print the executed cmd as a single string instead of a list of arguments, and add a few tests.
Should improve the situation on #122 

We could argue the tests are not necessary, remove them and remove the new function from the Vcs.mli API.