### PR TITLE
Let ocamlformat format docstrings

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,3 @@
 version=0.12
 profile=conventional
+parse-docstrings=true

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -21,8 +21,7 @@ val pkg_version : string option Term.t
 (** A [--pkg-version] option to specify the packages version. *)
 
 val keep_v : bool Term.t
-(** A [--keep-v] option to not drop the 'v' at the beginning of
-   version strings. *)
+(** A [--keep-v] option to not drop the 'v' at the beginning of version strings. *)
 
 val dist_name : string option Term.t
 (** A [--name] option to specify the distribution name. *)
@@ -63,17 +62,16 @@ val yes : bool Term.t
 (** {1 Terms} *)
 
 val setup : unit Term.t
-(** [setup env] defines a basic setup common to all commands. The
-    setup does, by side effect, set {!Logs} log verbosity, adjusts
-    colored output and sets the current working directory. *)
+(** [setup env] defines a basic setup common to all commands. The setup does, by
+    side effect, set {!Logs} log verbosity, adjusts colored output and sets the
+    current working directory. *)
 
 (** {1 Verbosity propagation} *)
 
 val propagate_verbosity_to_pkg_file : unit -> Bos.Cmd.t
-(** [propagate_verbosity_to_pkg_file ()] is
-    a command line fragment that has the option to propagate
-    the current log verbosity to an invocation of the package
-    description. *)
+(** [propagate_verbosity_to_pkg_file ()] is a command line fragment that has the
+    option to propagate the current log verbosity to an invocation of the
+    package description. *)
 
 (** {1 Warnings and errors} *)
 

--- a/lib/app_log.mli
+++ b/lib/app_log.mli
@@ -1,7 +1,8 @@
 (** App level logs with distinct headers based on the nature of the message *)
 
 val status : ?src:Logs.src -> 'a Logs.log
-(** For informative messages about what's currently happening such as ["doing this"] *)
+(** For informative messages about what's currently happening such as
+    ["doing this"] *)
 
 val question : ?src:Logs.src -> 'a Logs.log
 (** For prompts *)

--- a/lib/archive.mli
+++ b/lib/archive.mli
@@ -16,17 +16,15 @@ val tar :
   root:Fpath.t ->
   mtime:int ->
   (string, R.msg) result
-(** [tar dir ~exclude_paths ~root ~mtime] is a (us)tar archive that
-    contains the file hierarchy [dir] except the relative hierarchies
-    present in [exclude_paths]. In the archive, members of [dir] are
-    rerooted at [root] and sorted according to {!Fpath.compare}. They
-    have their modification time set to [mtime] and their file
-    permissions are [0o775] for directories and files executable by the
-    user and [0o664] for other files. No other file metadata is
-    preserved.
+(** [tar dir ~exclude_paths ~root ~mtime] is a (us)tar archive that contains the
+    file hierarchy [dir] except the relative hierarchies present in
+    [exclude_paths]. In the archive, members of [dir] are rerooted at [root] and
+    sorted according to {!Fpath.compare}. They have their modification time set
+    to [mtime] and their file permissions are [0o775] for directories and files
+    executable by the user and [0o664] for other files. No other file metadata
+    is preserved.
 
-    {b Note.} This is a pure OCaml implementation, no [tar] tool is
-    needed. *)
+    {b Note.} This is a pure OCaml implementation, no [tar] tool is needed. *)
 
 (** {1 Bzip2 compression and unarchiving} *)
 
@@ -41,10 +39,9 @@ val ensure_tar : unit -> (unit, R.msg) result
 (** [ensure_tar ()] makes sure the [tar] utility is available. *)
 
 val untbz : dry_run:bool -> ?clean:bool -> Fpath.t -> (Fpath.t, R.msg) result
-(** [untbz ~clean ar] untars the tar bzip2 archive [ar] in the same
-    directory as [ar] and returns a base directory for [ar]. If [clean]
-    is [true] (defaults to [false]) first delete the base directory if
-    it exists. *)
+(** [untbz ~clean ar] untars the tar bzip2 archive [ar] in the same directory as
+    [ar] and returns a base directory for [ar]. If [clean] is [true] (defaults
+    to [false]) first delete the base directory if it exists. *)
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/distrib.mli
+++ b/lib/distrib.mli
@@ -19,34 +19,43 @@ val v :
   unit ->
   t
 (** [distrib ~massage ~exclude_paths ()] influences the distribution creation
-      process performed by the [dune-release] tool.
-      See the {{!distdetails}full details about distribution creation}.
+    process performed by the [dune-release] tool. See the {{!distdetails} full
+    details about distribution creation}.
 
-      In the following the {e distribution build directory} is a
-      private clone of the package's source repository's [HEAD] when
-      [dune-release distrib] is invoked.
-      {ul
-      {- [massage] is invoked in the distribution build directory,
-         before archiving. It can be used to
-         generate distribution time build artefacts. Defaults to {!massage}.}
-      {- [exclude_paths ()] is invoked in the distribution build
-         directory, after massaging, to determine the paths that are
-         excluded from being added to the distribution archive. Defaults to
-         {!exclude_paths}.}} *)
+    In the following the {e distribution build directory} is a private clone of
+    the package's source repository's [HEAD] when [dune-release distrib] is
+    invoked.
+
+    - [massage] is invoked in the distribution build directory, before
+      archiving. It can be used to generate distribution time build artefacts.
+      Defaults to {!massage}.
+    - [exclude_paths ()] is invoked in the distribution build directory, after
+      massaging, to determine the paths that are excluded from being added to
+      the distribution archive. Defaults to {!exclude_paths}. *)
 
 val default_massage : unit -> (unit, R.msg) result
-(** [default_massage] is the default distribution massaging
-    function. It is invoked in the distribution build directory and
-    does nothing. *)
+(** [default_massage] is the default distribution massaging function. It is
+    invoked in the distribution build directory and does nothing. *)
 
 val default_exclude_paths : unit -> (Fpath.t list, R.msg) result
-(** [default_exclude_paths ()] is the default list of paths to exclude
-    from the distribution archive. It is invoked in the distribution build
-    directory and returns the following static set of files.
+(** [default_exclude_paths ()] is the default list of paths to exclude from the
+    distribution archive. It is invoked in the distribution build directory and
+    returns the following static set of files.
 
     {[
-      fun () -> Ok [".git"; ".gitignore"; ".gitattributes"; ".hg"; ".hgignore";
-                    "build"; "Makefile"; "_build"]]} *)
+      fun () ->
+        Ok
+          [
+            ".git";
+            ".gitignore";
+            ".gitattributes";
+            ".hg";
+            ".hgignore";
+            "build";
+            "Makefile";
+            "_build";
+          ]
+    ]} *)
 
 val massage : t -> unit -> (unit, R.msg) result
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -10,18 +10,18 @@ open Bos_setup
 
 module Parse : sig
   val user_from_remote : string -> string option
-  (** [user_from_remote remote_uri] is the username in the github URI [remote_uri], ie:
+  (** [user_from_remote remote_uri] is the username in the github URI
+      [remote_uri], ie:
 
       - [user_from_remote_uri "git@github.com:username/repo.git"] returns
         [Some "username"]
       - [user_from_remote_uri "https://github.com/username/repo.git"] returns
         [Some "username"].
-      - Returns [None] if [remote_uri] isn't in the expected format.
-  *)
+      - Returns [None] if [remote_uri] isn't in the expected format. *)
 
   val archive_upload_url : string -> (string, R.msg) Result.result
-  (** [archive_upload_url response] extracts the browser_download_url field from a github
-      release asset upload response. *)
+  (** [archive_upload_url response] extracts the browser_download_url field from
+      a github release asset upload response. *)
 end
 
 (** {1 Publish} *)
@@ -33,8 +33,8 @@ val publish_distrib :
   yes:bool ->
   Pkg.t ->
   (string, R.msg) Result.result
-(** Push the tag, create a Github release, upload the distribution archive and return the
-    release archive download URL *)
+(** Push the tag, create a Github release, upload the distribution archive and
+    return the release archive download URL *)
 
 val publish_doc :
   dry_run:bool ->

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -8,5 +8,5 @@ val all : t list
 
 val lint_pkg :
   dry_run:bool -> dir:Fpath.t -> Pkg.t -> t list -> (int, R.msg) result
-(** [lint_pkg ~dry_run ~dir pkg lints] performs the lint checks in [lints] on [pkg]
-    located in [dir]. *)
+(** [lint_pkg ~dry_run ~dir pkg lints] performs the lint checks in [lints] on
+    [pkg] located in [dir]. *)

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -24,17 +24,15 @@ val prepare :
   version:string ->
   string list ->
   (string, R.msg) result
-(** [prepare ~local_repo ~version pkgs] adds the packages
-   [pkg.version] to a new branch in the local opam repository
-   [local_repo], using the commit message [msg] (if any). Return the
-   new branch. *)
+(** [prepare ~local_repo ~version pkgs] adds the packages [pkg.version] to a new
+    branch in the local opam repository [local_repo], using the commit message
+    [msg] (if any). Return the new branch. *)
 
 (** {1:pkgs Packages} *)
 
 val ocaml_base_packages : String.set
-(** [ocaml_base_packages] are the base opam packages distributed
-    with OCaml: ["base-bigarray"], ["base-bytes"], ["base-threads"],
-    ["base-unix"]. *)
+(** [ocaml_base_packages] are the base opam packages distributed with OCaml:
+    ["base-bigarray"], ["base-bytes"], ["base-threads"], ["base-unix"]. *)
 
 (** {1:file Files} *)
 
@@ -43,15 +41,13 @@ module File : sig
   (** {1:file opam file} *)
 
   val field_names : String.set
-  (** [field_names] is the maximal domain of the map returned by
-      {!fields}, excluding extension fields (not yet supported by
-      [opam-lib] 1.2.2). *)
+  (** [field_names] is the maximal domain of the map returned by {!fields},
+      excluding extension fields (not yet supported by [opam-lib] 1.2.2). *)
 
   val fields : dry_run:bool -> Fpath.t -> (string list String.map, R.msg) result
-  (** [fields f] returns a simplified model of the fields of the opam
-      file [f]. The domain of the result is included in
-      {!field_names}. Note that the [depends:] and [depopts:] fields
-      are returned without version constraints. *)
+  (** [fields f] returns a simplified model of the fields of the opam file [f].
+      The domain of the result is included in {!field_names}. Note that the
+      [depends:] and [depopts:] fields are returned without version constraints. *)
 
   (** {1:deps Dependencies} *)
 
@@ -66,8 +62,7 @@ module Descr : sig
   (** {1:descr Descr file} *)
 
   type t = string * string option
-  (** The type for opam [descr] files, the package synopsis and the
-      description. *)
+  (** The type for opam [descr] files, the package synopsis and the description. *)
 
   val of_string : string -> (t, R.msg) result
   (** [of_string s] is a description from the string [s]. *)
@@ -76,13 +71,12 @@ module Descr : sig
   (** [to_string d] is [d] as a string. *)
 
   val of_readme : ?flavour:Text.flavour -> string -> (t, R.msg) result
-  (** [of_readme r] extracts an opam description file from a readme [r]
-      with a certain structure. *)
+  (** [of_readme r] extracts an opam description file from a readme [r] with a
+      certain structure. *)
 
   val of_readme_file : Fpath.t -> (t, R.msg) result
-  (** [of_readme_file f] extracts an opam description file from
-      a readme file [f] using {!Text.flavour_of_fpath} and
-      {!of_readme}. *)
+  (** [of_readme_file f] extracts an opam description file from a readme file
+      [f] using {!Text.flavour_of_fpath} and {!of_readme}. *)
 end
 
 (** [url] files. *)
@@ -90,13 +84,13 @@ module Url : sig
   (** {1:url Url file} *)
 
   val v : uri:string -> file:string -> OpamFile.URL.t
-  (** [v ~uri ~file] is an URL file for URI [uri] with
-      checksums computes on [file]. *)
+  (** [v ~uri ~file] is an URL file for URI [uri] with checksums computes on
+      [file]. *)
 
   val with_distrib_file :
     dry_run:bool -> uri:string -> Fpath.t -> (OpamFile.URL.t, R.msg) result
-  (** [with_distrib_file ~uri f] is an URL file for URI [uri] with
-      the checksum of file [f]. *)
+  (** [with_distrib_file ~uri f] is an URL file for URI [uri] with the checksum
+      of file [f]. *)
 end
 
 val version : [ `v1_2_2 | `v2 ] Lazy.t

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -44,8 +44,8 @@ val name : t -> (string, R.msg) result
 (** [name p] is [p]'s name. *)
 
 val with_name : t -> string -> t
-(** [with_name t n] is [r] such that like [name r] is [n] and [f r] is
-    [f t] otherwise. *)
+(** [with_name t n] is [r] such that like [name r] is [n] and [f r] is [f t]
+    otherwise. *)
 
 val version : t -> (string, R.msg) result
 (** [version p] is [p]'s version string.*)
@@ -92,9 +92,8 @@ val licenses : t -> (Fpath.t list, R.msg) result
 (** [licenses p] are [p]'s license files. *)
 
 val distrib_uri : ?raw:bool -> t -> (string, R.msg) result
-(** [distrib_uri p] is [p]'s distribution URI. If [raw] is [true]
-    defaults to [false], [p]'s raw URI distribution pattern is
-    returned. *)
+(** [distrib_uri p] is [p]'s distribution URI. If [raw] is [true] defaults to
+    [false], [p]'s raw URI distribution pattern is returned. *)
 
 val distrib_file : dry_run:bool -> t -> (Fpath.t, R.msg) result
 (** [distrib_file p] is [p]'s distribution archive. *)
@@ -106,20 +105,19 @@ val publish_msg : t -> (string, R.msg) result
 
 val distrib_archive :
   dry_run:bool -> keep_dir:bool -> t -> (Fpath.t, R.msg) result
-(** [distrib_archive ~keep_dir p] creates a distribution archive for
-    [p] and returns its path. If [keep_dir] is [true] the repository
-    checkout used to create the distribution archive is kept in the
-    build directory. *)
+(** [distrib_archive ~keep_dir p] creates a distribution archive for [p] and
+    returns its path. If [keep_dir] is [true] the repository checkout used to
+    create the distribution archive is kept in the build directory. *)
 
 val distrib_archive_path : t -> (Fpath.t, Rresult.R.msg) result
 
 val archive_url_path : t -> (Fpath.t, R.msg) result
-(** [archive_url_path] is the path to the file where the archive download URL is saved *)
+(** [archive_url_path] is the path to the file where the archive download URL is
+    saved *)
 
 val distrib_filename : ?opam:bool -> t -> (Fpath.t, R.msg) result
-(** [distrib_filename ~opam p] is a distribution filename for [p].  If
-    [opam] is [true] (defaults to [false]), the name follows opam's
-    naming conventions. *)
+(** [distrib_filename ~opam p] is a distribution filename for [p]. If [opam] is
+    [true] (defaults to [false]), the name follows opam's naming conventions. *)
 
 val publish_artefacts :
   t -> ([ `Distrib | `Doc | `Alt of string ] list, R.msg) result

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -1,12 +1,13 @@
 val confirm : question:('a, unit) Logs.msgf -> yes:bool -> bool
-(** Promtps the user for confirmation.
-    [confirm ~question ~yes] uses the message formatting function [question] to format and log
-    a message with the app level and wait for a yes or no answer from the user.
-    Returns [true] for yes. Defaults to yes if the user just press enter.
-    If [yes] then just skip the prompt and returns [true].
-    E.g. [confirm ~question:(fun l -> l "Do you want some %a?" Fmt.(styled `Bold string) "coffee")] *)
+(** Promtps the user for confirmation. [confirm ~question ~yes] uses the message
+    formatting function [question] to format and log a message with the app
+    level and wait for a yes or no answer from the user. Returns [true] for yes.
+    Defaults to yes if the user just press enter. If [yes] then just skip the
+    prompt and returns [true]. E.g.
+    [confirm ~question:(fun l -> l "Do you want some %a?" Fmt.(styled `Bold
+    string) "coffee")] *)
 
 val confirm_or_abort :
   question:('a, unit) Logs.msgf -> yes:bool -> (unit, Rresult.R.msg) result
-(** Same as [confirm] but returns [Ok ()] for yes and [Error (`Msg "Aborting on user demand")] for
-    no *)
+(** Same as [confirm] but returns [Ok ()] for yes and
+    [Error (`Msg "Aborting on user demand")] for no *)

--- a/lib/sos.mli
+++ b/lib/sos.mli
@@ -16,11 +16,11 @@
 
 (** Safe OS operations.
 
-   All the commands in that module can have side-effects. They also
-   all take a [--dry-run] paramater which cause the side-effect to be
-   discarded and to display a message instead. Some of these commands
-   also have a `[--force]` option: this causes the message to be
-   printed AND the side-effects to be caused.  *)
+    All the commands in that module can have side-effects. They also all take a
+    [--dry-run] paramater which cause the side-effect to be discarded and to
+    display a message instead. Some of these commands also have a `[--force]`
+    option: this causes the message to be printed AND the side-effects to be
+    caused. *)
 
 type error = Bos_setup.R.msg
 
@@ -94,10 +94,12 @@ val cp :
   src:Fpath.t ->
   dst:Fpath.t ->
   (unit, error) result
-(** [cp ~dry_run ~rec ~force ~src ~dst] copies [src] to [dst]. If [rec] is true, copies directories
-    recursively. If [force] is true, overwrite existing files. The usual [force] arguments from
-    other functions in this module is renamed [force_side_effects] here. *)
+(** [cp ~dry_run ~rec ~force ~src ~dst] copies [src] to [dst]. If [rec] is true,
+    copies directories recursively. If [force] is true, overwrite existing
+    files. The usual [force] arguments from other functions in this module is
+    renamed [force_side_effects] here. *)
 
 val relativize : src:Fpath.t -> dst:Fpath.t -> (Fpath.t, error) result
-(** [relativize ~src ~dst] return a relative path from [src] to [dst]. If such a path can't be
-    expressed, i.e. [srs] and [dst] don't have a common root, returns an error. *)
+(** [relativize ~src ~dst] return a relative path from [src] to [dst]. If such a
+    path can't be expressed, i.e. [srs] and [dst] don't have a common root,
+    returns an error. *)

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -6,16 +6,14 @@ module Sbytes : sig
   (** An alias for the type of byte sequences. *)
 
   val make : int -> char -> (t, [> R.msg ]) result
-  (** [make n c] returns a new byte sequence of length [n], filled with the
-      byte [c].
-      Returns an error message if [n < 0] or [n > Sys.max_string_length]. *)
+  (** [make n c] returns a new byte sequence of length [n], filled with the byte
+      [c]. Returns an error message if [n < 0] or [n > Sys.max_string_length]. *)
 
   val blit_string :
     string -> int -> t -> int -> int -> (unit, [> R.msg ]) result
   (** [blit src srcoff dst dstoff len] copies [len] bytes from string [src],
       starting at index [srcoff], to byte sequence [dst], starting at index
-      [dstoff].
-      Returns an error message if [srcoff] and [len] do not designate a valid
-      range of [src], or if [dstoff] and [len] do not designate a valid range of
-      [dst]. *)
+      [dstoff]. Returns an error message if [srcoff] and [len] do not designate
+      a valid range of [src], or if [dstoff] and [len] do not designate a valid
+      range of [dst]. *)
 end

--- a/lib/text.mli
+++ b/lib/text.mli
@@ -10,72 +10,68 @@ open Bos_setup
 
 (** {1 Marked-up text files}
 
-    {b Warning.} Some of the following functions are not serious and can
-    break on certain valid inputs in all sorts of fashion. To understand
-    breakage bear in mind that they operate line-wise. *)
+    {b Warning.} Some of the following functions are not serious and can break
+    on certain valid inputs in all sorts of fashion. To understand breakage bear
+    in mind that they operate line-wise. *)
 
 type flavour = [ `Markdown | `Asciidoc ]
 (** The type for text document formats. *)
 
 val flavour_of_fpath : Fpath.t -> flavour option
-(** [flavour_of_fpath p] determines a flavour according to the
-    extension of [p] as follows:
-    {ul
-    {- [Some `Markdown] for [.md]}
-    {- [Some `Asciidoc] for [.asciidoc] or [.adoc]}
-    {- [None] otherwise}} *)
+(** [flavour_of_fpath p] determines a flavour according to the extension of [p]
+    as follows:
+
+    - [Some `Markdown] for [.md]
+    - [Some `Asciidoc] for [.asciidoc] or [.adoc]
+    - [None] otherwise *)
 
 val head : ?flavour:flavour -> string -> (string * string) option
-(** [head ~flavour text] extracts the {e head} of the document [text] of
-    flavour [flavour] (defaults to [`Markdown]).
+(** [head ~flavour text] extracts the {e head} of the document [text] of flavour
+    [flavour] (defaults to [`Markdown]).
 
     The head is defined as follows:
-    {ul
-    {- Anything before the first header is discarded.}
-    {- The first header is kept in the first component}
-    {- Everything that follows until the next header of the same or greater
-       level is kept discarding trailing blank lines.}} *)
+
+    - Anything before the first header is discarded.
+    - The first header is kept in the first component
+    - Everything that follows until the next header of the same or greater level
+      is kept discarding trailing blank lines. *)
 
 val header_title : ?flavour:flavour -> string -> string
-(** [header_title ~flavour text] extract the title of a header [text]
-    of flavour [flavour] (defaults to [`Markdown]). *)
+(** [header_title ~flavour text] extract the title of a header [text] of flavour
+    [flavour] (defaults to [`Markdown]). *)
 
 (** {1 Toy change log parsing} *)
 
 val change_log_last_entry :
   ?flavour:flavour -> string -> (string * (string * string)) option
-(** [change_log_last_version ~flavour text] tries to parse the last
-    change log entry of [text] (i.e. the {!head} of [text]) into
-    [Some (version, (header, text))], where [(header,text)] is the
-    result of {!head} and [version] a version number extracted from
-    [header]. *)
+(** [change_log_last_version ~flavour text] tries to parse the last change log
+    entry of [text] (i.e. the {!head} of [text]) into
+    [Some (version, (header, text))], where [(header,text)] is the result of
+    {!head} and [version] a version number extracted from [header]. *)
 
 val change_log_file_last_entry :
   Fpath.t -> (string * (string * string), R.msg) result
-(** [change_log_file_last_entry file] tries to parse the last
-    change log entry of the file [file] using {!flavour_of_fpath} and
-    and {!change_log_last_entry}. *)
+(** [change_log_file_last_entry file] tries to parse the last change log entry
+    of the file [file] using {!flavour_of_fpath} and and
+    {!change_log_last_entry}. *)
 
 (** {1 Toy URI parsing} *)
 
 val split_uri : ?rel:bool -> string -> (string * string * string) option
-(** [split_uri uri] splits [uri] into a triple [(scheme, host, path)]. If
-    [rel] is [true] (defaults to [false]), a leading ["/"] in [path] is
-    removed. *)
+(** [split_uri uri] splits [uri] into a triple [(scheme, host, path)]. If [rel]
+    is [true] (defaults to [false]), a leading ["/"] in [path] is removed. *)
 
 (** {1 Edit and page text} *)
 
 val edit_file : Fpath.t -> (int, R.msg) result
-(** [edit_file f] invokes the tool mentioned in the [EDITOR]
-    environment variable with [f] and returns the exit code of
-    the program. *)
+(** [edit_file f] invokes the tool mentioned in the [EDITOR] environment
+    variable with [f] and returns the exit code of the program. *)
 
 val find_pager : don't:bool -> (Cmd.t option, R.msg) result
-(** [find ~no_pager] is an optional pager command. If [don't] is
-    [true] returns [None]. Otherwise first consults the [PAGER] environment
-    variable, then tries [less] or [more] in that order. If the [TERM]
-    environment variable is ["dumb"] or undefined unconditionaly returns
-    [None]. *)
+(** [find ~no_pager] is an optional pager command. If [don't] is [true] returns
+    [None]. Otherwise first consults the [PAGER] environment variable, then
+    tries [less] or [more] in that order. If the [TERM] environment variable is
+    ["dumb"] or undefined unconditionaly returns [None]. *)
 
 (** Pretty printers. *)
 module Pp : sig

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -19,9 +19,9 @@ val pp_kind : Format.formatter -> kind -> unit
 (** [pp_kind ppf k] prints an unspecified representation of [k] on [ppf]. *)
 
 type commit_ish = string
-(** The type for symbols resolving to a commit. The module uses
-    ["HEAD"] for specifying the current checkout; use this symbol even
-    if the underlying VCS is [`Hg]. *)
+(** The type for symbols resolving to a commit. The module uses ["HEAD"] for
+    specifying the current checkout; use this symbol even if the underlying VCS
+    is [`Hg]. *)
 
 type t
 (** The type for version control systems repositories. *)
@@ -35,13 +35,11 @@ val dir : t -> Fpath.t
 val cmd : t -> Bos.Cmd.t
 (** [cmd r] is the base VCS command to use to act on [r].
 
-    {b Warning} Prefer the functions below to remain VCS
-    independent. *)
+    {b Warning} Prefer the functions below to remain VCS independent. *)
 
 val find : ?dir:Fpath.t -> unit -> (t option, R.msg) result
-(** [find ~dir ()] looks for a VCS repository in working directory
-    [dir] (not the repository directory like [.git], default is guessed
-    automatically). *)
+(** [find ~dir ()] looks for a VCS repository in working directory [dir] (not
+    the repository directory like [.git], default is guessed automatically). *)
 
 val get : ?dir:Fpath.t -> unit -> (t, R.msg) result
 (** [get] is like {!find} but returns an error if no VCS was found. *)
@@ -52,39 +50,39 @@ val pp : Format.formatter -> t -> unit
 (** {1:state Repository state} *)
 
 val is_dirty : t -> (bool, R.msg) result
-(** [is_dirty r] is [Ok true] iff the working tree of [r] has
-    uncommited changes. *)
+(** [is_dirty r] is [Ok true] iff the working tree of [r] has uncommited
+    changes. *)
 
 val not_dirty : t -> (unit, R.msg) result
-(** [not_dirty] is [Ok ()] iff the working directory of [r] is not
-    dirty and an error that enjoins to stash or commit otherwise. *)
+(** [not_dirty] is [Ok ()] iff the working directory of [r] is not dirty and an
+    error that enjoins to stash or commit otherwise. *)
 
 val file_is_dirty : t -> Fpath.t -> (bool, R.msg) result
 (** [file_id_dirty r f] is [Ok true] iff [f] has uncommited changes. *)
 
 val head : ?dirty:bool -> t -> (string, R.msg) result
-(** [head ~dirty r] is the HEAD commit identifier of the repository
-    [r]. If [dirty] is [true] (default), and indicator is appended to
-    the commit identifier if the working tree of [r] {!is_dirty}. *)
+(** [head ~dirty r] is the HEAD commit identifier of the repository [r]. If
+    [dirty] is [true] (default), and indicator is appended to the commit
+    identifier if the working tree of [r] {!is_dirty}. *)
 
 val commit_id :
   ?dirty:bool -> ?commit_ish:commit_ish -> t -> (string, R.msg) result
-(** [commit_id ~dirty ~commit_ish r] is the object name (identifier)
-    of [commit_ish] (defaults to ["HEAD"]). If [commit_ish] is ["HEAD"]
-    and [dirty] is [true] (default) and indicator is appended to the
-    identifier if the working tree is dirty. *)
+(** [commit_id ~dirty ~commit_ish r] is the object name (identifier) of
+    [commit_ish] (defaults to ["HEAD"]). If [commit_ish] is ["HEAD"] and [dirty]
+    is [true] (default) and indicator is appended to the identifier if the
+    working tree is dirty. *)
 
 val commit_ptime_s :
   dry_run:bool -> ?commit_ish:commit_ish -> t -> (int, R.msg) result
-(** [commit_ptime_s t ~commit_ish] is the POSIX time in seconds of
-    commit [commit_ish] (defaults to ["HEAD"]) of repository [r]. *)
+(** [commit_ptime_s t ~commit_ish] is the POSIX time in seconds of commit
+    [commit_ish] (defaults to ["HEAD"]) of repository [r]. *)
 
 val describe :
   ?dirty:bool -> ?commit_ish:commit_ish -> t -> (string, R.msg) result
-(** [describe ~dirty ~commit_ish r] identifies [commit_ish] (defaults
-    to ["HEAD"]) using tags from the repository [r]. If [commit_ish] is
-    ["HEAD"] and [dirty] is [true] (default) an indicator is appended
-    to the identifier if the working tree is dirty. *)
+(** [describe ~dirty ~commit_ish r] identifies [commit_ish] (defaults to
+    ["HEAD"]) using tags from the repository [r]. If [commit_ish] is ["HEAD"]
+    and [dirty] is [true] (default) an indicator is appended to the identifier
+    if the working tree is dirty. *)
 
 val tags : t -> (string list, R.msg) result
 (** [tags r] is the list of tags in the repo [r]. *)
@@ -98,13 +96,12 @@ val changes :
   t ->
   after:commit_ish ->
   ((string * string) list, R.msg) result
-(** [changes r ~after ~until] is the list of commits with their
-    one-line message from commit-ish [after] to commit-ish [until]
-    (defaults to ["HEAD"]). *)
+(** [changes r ~after ~until] is the list of commits with their one-line message
+    from commit-ish [after] to commit-ish [until] (defaults to ["HEAD"]). *)
 
 val tracked_files : ?tree_ish:string -> t -> (Fpath.t list, R.msg) result
-(** [tracked_files ~tree_ish r] are the files tracked by the tree
-    object [tree_ish] (defaults to ["HEAD"]). *)
+(** [tracked_files ~tree_ish r] are the files tracked by the tree object
+    [tree_ish] (defaults to ["HEAD"]). *)
 
 (** {1:ops Repository operations} *)
 
@@ -123,13 +120,13 @@ val checkout :
   t ->
   commit_ish:commit_ish ->
   (unit, R.msg) result
-(** [checkout r ~branch commit_ish] checks out [commit_ish]. Checks
-    out in a new branch [branch] if provided. *)
+(** [checkout r ~branch commit_ish] checks out [commit_ish]. Checks out in a new
+    branch [branch] if provided. *)
 
 val commit_files :
   dry_run:bool -> ?msg:string -> t -> Fpath.t list -> (unit, R.msg) result
-(** [commit_files r ~msg files] commits the file [files] with message
-    [msg] (if unspecified the VCS should prompt). *)
+(** [commit_files r ~msg files] commits the file [files] with message [msg] (if
+    unspecified the VCS should prompt). *)
 
 val tag :
   dry_run:bool ->
@@ -140,11 +137,10 @@ val tag :
   t ->
   string ->
   (unit, R.msg) result
-(** [tag r ~force ~sign ~msg ~commit_ish t] tags [commit_ish] with [t]
-    and message [msg] (if unspecified the VCS should prompt).  if
-    [sign] is [true] (defaults to [false]) signs the tag ([`Git] repos
-    only).  If [force] is [true] (default to [false]) doesn't fail if
-    the tag already exists. *)
+(** [tag r ~force ~sign ~msg ~commit_ish t] tags [commit_ish] with [t] and
+    message [msg] (if unspecified the VCS should prompt). if [sign] is [true]
+    (defaults to [false]) signs the tag ([`Git] repos only). If [force] is
+    [true] (default to [false]) doesn't fail if the tag already exists. *)
 
 val delete_tag : dry_run:bool -> t -> string -> (unit, R.msg) result
 (** [delete_tag r t] deletes tag [t] in repo [r]. *)

--- a/lib/xdg.mli
+++ b/lib/xdg.mli
@@ -1,8 +1,7 @@
 (* From dune API. TODO: use the API directly once it's public. *)
 
 (** Implement the XDG specification
-    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-*)
+    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html *)
 
 val config_dir : string
 (** The directory where the application should read/write config files. *)


### PR DESCRIPTION
I was writing documentation for #197 and noticed we were not formatting those (not enabled by default because officially it's still experimental but it's working great).
No need for an entry in the changelog IMO.