### PR TITLE
Do not echo input characters when reading token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   and handles HTTPS URIs (#183, @gpetiot)
 - Ignore backup files when looking for README, CHANGES and LICENSE files
   (#194, @gpetiot)
+- Do not echo input characters when reading token (#199, @gpetiot)
 
 ### Removed
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -164,7 +164,7 @@ let () = at_exit cleanup
 
 let get_token () =
   let rec aux () =
-    match read_line () with
+    match Stdext.Unix.read_line ~echo_input:false () with
     | "" -> aux ()
     | s -> s
     | exception End_of_file ->

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -30,3 +30,18 @@ module Path = struct
           String.equal name_wo_ext (String.Ascii.lowercase normalized))
       files
 end
+
+module Unix = struct
+  let maybe_echo_input echo_input f x =
+    if echo_input then f x
+    else
+      let open Unix in
+      let term_io = tcgetattr stdin in
+      tcsetattr stdin TCSANOW { term_io with c_echo = false };
+      let input = f x in
+      tcsetattr stdin TCSANOW term_io;
+      input
+
+  let read_line ?(echo_input = true) () =
+    maybe_echo_input echo_input read_line ()
+end

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -30,3 +30,11 @@ module Path : sig
       whose name without the extension is equal to [name_wo_ext]. Backup files
       are ignored. *)
 end
+
+(** Interface to the Unix system. *)
+module Unix : sig
+  val read_line : ?echo_input:bool -> unit -> string
+  (** [read_line ?echo_input ()] reads a line (terminated before a CR) on the
+      standard input. If [echo_input] is [true] (by default) input characters
+      are echoed on the standard output. *)
+end


### PR DESCRIPTION
Fix #124

- Add a new `Stdext.Unix.read_line` function with a `echo_input` flag (only works on Unix)
- tested with `utop` (it works)